### PR TITLE
Replace `larapack/dd` with `symfony/var-dumper`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.2",
-        "larapack/dd": "^1.1",
         "phpstan/phpstan": "^1.10",
-        "friendsofphp/php-cs-fixer": "^3.21"
+        "friendsofphp/php-cs-fixer": "^3.21",
+        "symfony/var-dumper": "^7.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1200340fe6747edb04f657f1beec77b6",
+    "content-hash": "3c938039bf8c00ff8a1575f78fda3fc6",
     "packages": [
         {
             "name": "assertchris/ellison",
@@ -4614,46 +4614,6 @@
             "time": "2024-08-07T17:03:09+00:00"
         },
         {
-            "name": "larapack/dd",
-            "version": "1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/larapack/dd.git",
-                "reference": "561b5111a13d0094b59b5c81b1572489485fb948"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/larapack/dd/zipball/561b5111a13d0094b59b5c81b1572489485fb948",
-                "reference": "561b5111a13d0094b59b5c81b1572489485fb948",
-                "shasum": ""
-            },
-            "require": {
-                "symfony/var-dumper": "*"
-            },
-            "type": "package",
-            "autoload": {
-                "files": [
-                    "src/helper.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mark Topper",
-                    "email": "hi@webman.io"
-                }
-            ],
-            "description": "`dd` is a helper method in Laravel. This package will add the `dd` to your application.",
-            "support": {
-                "issues": "https://github.com/larapack/dd/issues",
-                "source": "https://github.com/larapack/dd/tree/master"
-            },
-            "time": "2016-12-15T09:34:34+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.12.0",
             "source": {
@@ -7468,5 +7428,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
`larapack/dd` no longer provides any value, because now `symfony/var-dumper` ships `dd` and `dump` helpers on its own.