### PR TITLE
Fix undef matrix variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.3'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
 
       - name: Install dependencies


### PR DESCRIPTION
Follows 0dc097ff729fb91d1c08b8478c0da5603fcdcead.

Based on the most recent build, GitHub silently expand it to null, which setup-php then ignores in favour of the default, which is currently 8.3.