### PR TITLE
feat: support dark mode

### DIFF
--- a/app/Front/Code/code.view.php
+++ b/app/Front/Code/code.view.php
@@ -3,6 +3,7 @@
 /** @var \Tempest\View\GenericView $this */
 
 use App\Front\Code\CodeController;
+
 use function Tempest\uri;
 
 ?>
@@ -11,8 +12,8 @@ use function Tempest\uri;
     <form action="<?= uri([CodeController::class, 'submit']) ?>" method="POST">
         <div class="flex justify-center items-center flex-col w-3/5 mx-auto gap-4 font-mono">
             <label for="code" class="text-xl">Paste your code</label>
-            <textarea name="code" id="code" class="border-2 border-blue-300 w-full p-4 rounded" rows="20" autofocus></textarea>
-            <input type="submit" name="Generate" class="bg-[#4f95d1] text-white font-bold p-4 py-3 hover:bg-[#4AB1D1] rounded cursor-pointer"/>
+            <textarea name="code" id="code" class="border-2 border-[--primary] w-full p-4 rounded bg-[var(--code-background)] text-[var(--foreground)]" rows="20" autofocus></textarea>
+            <input type="submit" name="Generate" class="bg-[var(--link-color)] text-white font-bold p-4 py-3 hover:bg-[var(--link-hover-color)] rounded cursor-pointer"/>
         </div>
     </form>
 </x-base>

--- a/app/Front/Docs/docs.view.php
+++ b/app/Front/Docs/docs.view.php
@@ -24,7 +24,7 @@
     }
   </script>
   <!-- Main container -->
-  <main class="docs max-w-full md:max-w-[1000px] mx-auto md:grid md:grid-cols-12">
+  <main class="docs max-w-full md:max-w-[1500px] mx-auto md:grid md:grid-cols-12">
     <div class="md:col-span-3">
       <div class="
         md:sticky md:h-screen overflow-auto
@@ -90,29 +90,6 @@
                 >
                   <?= $chapter->title ?>
                 </a>
-
-                <?php if ($this->isCurrent($chapter) && ($subChapters = $this->getSubChapters()) !== []): ?>
-                <div class="
-                  hidden
-                  md:grid
-                  md:border-r
-                  md:border-[--border]
-                  md:pr-2
-                  text-sm
-                  gap-2
-                  mr-2
-                  mt-2
-                  mb-4
-                  pt-2
-                  pb-2
-                ">
-                  <?php foreach ($subChapters as $url => $title): ?>
-                    <a href="<?= $url ?>" class="hover:text-[--primary] hover:underline text--[--foreground] transition">
-                      <?= $title ?>
-                    </a>
-                  <?php endforeach; ?>
-                </div>
-                <?php endif ?>
               <?php } ?>
             </div>
           <?php } ?>
@@ -121,7 +98,7 @@
     </div>
 
     <!-- Docs content -->
-    <div class="px-4 md:px-6 pt-8 md:col-span-9">
+    <div class="px-4 md:px-6 pt-8 md:col-span-6">
       <?php if ($this->currentChapter) { ?>
         <div class="prose dark:prose-invert">
           <h1>
@@ -149,5 +126,30 @@
         </a>
       </div>
     </div>
+
+    <?php if (($subChapters = $this->getSubChapters()) !== []): ?>
+    <aside class="col-span-2">
+      <div class="
+          md:sticky md:h-screen overflow-auto
+          md:top-0 md:pt-9 md:pl-12
+          pl-4
+        ">
+        <div class="
+            hidden
+            md:grid
+            md:pl-2
+            text-sm
+            mr-2 mt-2 mb-4
+        ">
+            <h2 class="font-bold text-[--primary] mb-3">On this page</h2>
+            <?php foreach ($subChapters as $url => $title): ?>
+            <a href="<?= $url ?>" class="hover:text-[--primary] hover:underline text--[--foreground] transition mb-1.5">
+                <?= $title ?>
+            </a>
+            <?php endforeach; ?>
+        </div>
+      </div>
+    </aside>
+    <?php endif ?>
   </main>
 </x-base>

--- a/app/Front/Docs/docs.view.php
+++ b/app/Front/Docs/docs.view.php
@@ -2,10 +2,10 @@
 
 <x-base :title="$this->currentChapter->title">
 
-    <div class="px-4 text-center py-4 bg-[#4f95d1] font-bold text-white w-full z-[99] mb-4 flex items-center gap-2 justify-center">
+    <div class="px-4 text-center py-4 bg-[var(--card)] font-bold text-[var(--card-foreground)] w-full z-[99] mb-4 flex items-center gap-2 justify-center">
         <img src="/favicon/favicon-32x32.png" alt="favicon" class="h-[20px] hidden md:inline-block">
         <span>
-        Tempest is still a <span class="hl-attribute text-white">work in progress</span>. Visit our <a href="https://github.com/tempestphp/tempest-framework/issues" class="underline hover:no-underline">GitHub</a> or
+        Tempest is still a <span class="hl-attribute">work in progress</span>. Visit our <a href="https://github.com/tempestphp/tempest-framework/issues" class="underline hover:no-underline">GitHub</a> or
         <a href="https://discord.gg/pPhpTGUMPQ" class="underline hover:no-underline">Discord</a>
     </span>
     </div>
@@ -25,6 +25,7 @@
     </script>
     
     <div class="
+    docs
     max-w-full md:max-w-[1000px] mx-auto
     md:grid md:grid-cols-12
 ">
@@ -35,7 +36,7 @@
             px-2
         ">
                 <div class="md:hidden">
-                    <button onclick="toggleMenu()" class="flex gap-2">
+                    <button onclick="toggleMenu()" class="flex gap-2 bg-[--background] text-[var(--foreground)]">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
                         </svg>
@@ -44,62 +45,63 @@
                 </div>
 
                 <div id="menu" class="
-                hidden
-                gap-4
-                flex-wrap
-                mt-4
-                bg-blue-50
-                p-4
+                    hidden
+                    gap-4
+                    flex-wrap
+                    mt-4
+                    bg-[var(--menu-background)]
+                    p-4
 
-                md:bg-transparent
-                md:mt-4
-                md:grid
-                md:gap-4
-                md:border-r-2
-                md:border-[#4f95d1]
-                md:px-4
-                md:py-2
-                md:justify-end
-                justify-start
-            ">
-                    <h1 class="text-[#4f95d1] font-bold text-2xl">Tempest</h1>
+                    md:bg-transparent
+                    md:mt-4
+                    md:grid
+                    md:gap-4
+                    md:border-r-2
+                    md:border-[var(--border)]
+                    md:px-4
+                    md:py-2
+                    md:justify-end
+                    justify-start
+                ">
+                    <h1 class="text-[var(--primary)] font-bold text-2xl">Tempest</h1>
 
                     <?php foreach ($this->categories() as $category) { ?>
                         <div class="flex flex-col">
                             <?php if ($category !== 'intro') { ?>
-                                <h2 class="font-bold text-lg">
+                                <h2 class="font-bold text-lg text-[var(--foreground)]">
                                     <?= ucfirst($category) ?>
                                 </h2>
                             <?php } ?>
 
                             <?php foreach ($this->chaptersForCategory($category) as $chapter) { ?>
                                 <a href="<?= $chapter->getUri() ?>" class="
-                                menu-link
-                                px-4 py-2
-                                text-md
-                                inline-block
-                                rounded
-                                hover:text-[#4f95d1] hover:underline
+                                    menu-link
+                                    px-4 py-2
+                                    text-md
+                                    inline-block
+                                    rounded
+                                    hover:text-[--primary] hover:underline
+                                    text-[--foreground]
 
-                                md:bg-transparent
-                                md:px-0
-                                md:py-1
-                                md:inline
-                                md:text-base
-                                <?= $this->isCurrent($chapter) ? 'font-bold text-[#4f95d1]' : '' ?>
-                            "
+                                    md:bg-transparent
+                                    md:px-0
+                                    md:py-1
+                                    md:inline
+                                    md:text-base
+                                    <?= $this->isCurrent($chapter) ? 'font-bold text-[--primary]' : '' ?>
+                                "
                                 >
                                     <?= $chapter->title ?>
                                 </a>
 
                                 <?php
                                     if($this->isCurrent($chapter) && ($subChapters = $this->getSubChapters()) !== []):
-                                ?>
+                                        ?>
                                 <div class="
                                     hidden
                                     md:grid
                                     md:border-r
-                                    md:border-[#4f95d1]
+                                    md:border-[var(--border)]
                                     md:pr-2
                                     text-sm
                                     gap-2
@@ -110,7 +112,7 @@
                                     pb-2
                                 ">
                                     <?php foreach ($subChapters as $url => $title): ?>
-                                        <a href="<?= $url ?>" class="hover:text-[#4f95d1] hover:underline">
+                                        <a href="<?= $url ?>" class="hover:text-[--primary] hover:underline text--[--foreground] transition">
                                             <?= $title ?>
                                         </a>
                                     <?php endforeach; ?>
@@ -125,7 +127,7 @@
 
         <div class="px-4 md:px-6 pt-8 md:col-span-9">
             <?php if ($this->currentChapter) { ?>
-                <div class="prose">
+                <div class="prose dark:prose-invert">
                     <h1>
                         <?= $this->currentChapter->title ?>
                     </h1>
@@ -133,7 +135,7 @@
                 </div>
             <?php } ?>
 
-            <div class="bg-[#4f95d1] text-white font-bold rounded-md p-4 flex justify-between gap-2 my-6">
+            <div class="bg-[--card] text-[--card-foreground] font-bold rounded-md p-4 flex justify-between gap-2 my-6">
                 <div class="flex gap-1">
                     <a href="https://github.com/tempestphp/tempest-framework" class="underline hover:no-underline">GitHub</a>
                     •

--- a/app/Front/Docs/docs.view.php
+++ b/app/Front/Docs/docs.view.php
@@ -1,155 +1,153 @@
 <?php /** @var \App\Front\Docs\DocsView $this */ ?>
 
 <x-base :title="$this->currentChapter->title">
-
-    <div class="px-4 text-center py-4 bg-[var(--card)] font-bold text-[var(--card-foreground)] w-full z-[99] mb-4 flex items-center gap-2 justify-center">
-        <img src="/favicon/favicon-32x32.png" alt="favicon" class="h-[20px] hidden md:inline-block">
-        <span>
-        Tempest is still a <span class="hl-attribute">work in progress</span>. Visit our <a href="https://github.com/tempestphp/tempest-framework/issues" class="underline hover:no-underline">GitHub</a> or
-        <a href="https://discord.gg/pPhpTGUMPQ" class="underline hover:no-underline">Discord</a>
+  <!-- Banner -->
+  <div class="px-4 text-center py-4 bg-[--card] font-bold text-[--card-foreground] w-full z-[99] mb-4 flex items-center gap-2 justify-center">
+    <img src="/favicon/favicon-32x32.png" alt="favicon" class="h-[20px] hidden md:inline-block">
+    <span>
+      Tempest is still a <span class="hl-attribute">work in progress</span>. Visit our <a href="https://github.com/tempestphp/tempest-framework/issues" class="underline hover:no-underline">GitHub</a> or
+      <a href="https://discord.gg/pPhpTGUMPQ" class="underline hover:no-underline">Discord</a>
     </span>
-    </div>
+  </div>
+  <!-- Toggling menu -->
+  <script>
+    function toggleMenu() {
+      const menu = document.getElementById('menu');
 
-    <script>
-        function toggleMenu() {
-            const menu = document.getElementById('menu');
-
-            if (menu.classList.contains('hidden')) {
-                menu.classList.remove('hidden');
-                menu.classList.add('block');
-            } else {
-                menu.classList.remove('block');
-                menu.classList.add('hidden');
-            }
-        }
-    </script>
-    
-    <div class="
-    docs
-    max-w-full md:max-w-[1000px] mx-auto
-    md:grid md:grid-cols-12
-">
-        <div class="md:col-span-3">
-            <div class="
-            md:sticky md:h-screen overflow-auto
-            md:top-0 md:pt-4 md:px-6 md:text-right
-            px-2
+      if (menu.classList.contains('hidden')) {
+        menu.classList.remove('hidden');
+        menu.classList.add('block');
+      } else {
+        menu.classList.remove('block');
+        menu.classList.add('hidden');
+      }
+    }
+  </script>
+  <!-- Main container -->
+  <main class="docs max-w-full md:max-w-[1000px] mx-auto md:grid md:grid-cols-12">
+    <div class="md:col-span-3">
+      <div class="
+        md:sticky md:h-screen overflow-auto
+        md:top-0 md:pt-4 md:px-6 md:text-right
+        px-2
+      ">
+        <!-- Menu toggle button -->
+        <div class="md:hidden">
+          <button onclick="toggleMenu()" class="flex gap-2 bg-[--background] text-[var(--foreground)]">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
+            </svg>
+            <span>Menu</span>
+          </button>
+        </div>
+        <!-- Menu -->
+        <aside id="menu" class="
+          hidden
+          gap-4
+          flex-wrap
+          mt-4
+          p-4
+          md:bg-transparent
+          md:mt-4
+          md:grid
+          md:gap-4
+          md:border-r-2
+          md:border-[--border]
+          md:px-4
+          md:py-2
+          md:justify-end
+          justify-start
         ">
-                <div class="md:hidden">
-                    <button onclick="toggleMenu()" class="flex gap-2 bg-[--background] text-[var(--foreground)]">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
-                        </svg>
-                        <span>Menu</span>
-                    </button>
-                </div>
+          <h1 class="text-[--primary] font-bold text-2xl">Tempest</h1>
 
-                <div id="menu" class="
-                    hidden
-                    gap-4
-                    flex-wrap
-                    mt-4
-                    bg-[var(--menu-background)]
-                    p-4
+          <?php foreach ($this->categories() as $category) { ?>
+            <div class="flex flex-col">
+              <?php if ($category !== 'intro') { ?>
+                <h2 class="font-bold text-lg text-[--foreground]">
+                  <?= ucfirst($category) ?>
+                </h2>
+              <?php } ?>
+
+              <?php foreach ($this->chaptersForCategory($category) as $chapter) { ?>
+                <a
+                  href="<?= $chapter->getUri() ?>"
+                  class="
+                    menu-link
+                    px-4 py-2
+                    text-md
+                    inline-block
+                    rounded
+                    hover:text-[--primary] hover:underline
+                    text-[--foreground]
 
                     md:bg-transparent
-                    md:mt-4
-                    md:grid
-                    md:gap-4
-                    md:border-r-2
-                    md:border-[var(--border)]
-                    md:px-4
-                    md:py-2
-                    md:justify-end
-                    justify-start
-                ">
-                    <h1 class="text-[var(--primary)] font-bold text-2xl">Tempest</h1>
-
-                    <?php foreach ($this->categories() as $category) { ?>
-                        <div class="flex flex-col">
-                            <?php if ($category !== 'intro') { ?>
-                                <h2 class="font-bold text-lg text-[var(--foreground)]">
-                                    <?= ucfirst($category) ?>
-                                </h2>
-                            <?php } ?>
-
-                            <?php foreach ($this->chaptersForCategory($category) as $chapter) { ?>
-                                <a href="<?= $chapter->getUri() ?>" class="
-                                    menu-link
-                                    px-4 py-2
-                                    text-md
-                                    inline-block
-                                    rounded
-                                    hover:text-[--primary] hover:underline
-                                    text-[--foreground]
-
-                                    md:bg-transparent
-                                    md:px-0
-                                    md:py-1
-                                    md:inline
-                                    md:text-base
-                                    <?= $this->isCurrent($chapter) ? 'font-bold text-[--primary]' : '' ?>
-                                "
-                                >
-                                    <?= $chapter->title ?>
-                                </a>
-
-                                <?php
-                                    if($this->isCurrent($chapter) && ($subChapters = $this->getSubChapters()) !== []):
-                                        ?>
-                                <div class="
-                                    hidden
-                                    md:grid
-                                    md:border-r
-                                    md:border-[var(--border)]
-                                    md:pr-2
-                                    text-sm
-                                    gap-2
-                                    mr-2
-                                    mt-2
-                                    mb-4
-                                    pt-2
-                                    pb-2
-                                ">
-                                    <?php foreach ($subChapters as $url => $title): ?>
-                                        <a href="<?= $url ?>" class="hover:text-[--primary] hover:underline text--[--foreground] transition">
-                                            <?= $title ?>
-                                        </a>
-                                    <?php endforeach; ?>
-                                </div>
-                                <?php endif ?>
-                            <?php } ?>
-                        </div>
-                    <?php } ?>
-                </div>
-            </div>
-        </div>
-
-        <div class="px-4 md:px-6 pt-8 md:col-span-9">
-            <?php if ($this->currentChapter) { ?>
-                <div class="prose dark:prose-invert">
-                    <h1>
-                        <?= $this->currentChapter->title ?>
-                    </h1>
-                    <?= $this->currentChapter->body ?>
-                </div>
-            <?php } ?>
-
-            <div class="bg-[--card] text-[--card-foreground] font-bold rounded-md p-4 flex justify-between gap-2 my-6">
-                <div class="flex gap-1">
-                    <a href="https://github.com/tempestphp/tempest-framework" class="underline hover:no-underline">GitHub</a>
-                    •
-                    <a href="https://discord.gg/pPhpTGUMPQ" class="underline hover:no-underline">Discord</a>
-                </div>
-
-                <a
-                        :if="$this->nextChapter()"
-                        href="<?= $this->nextChapter()?->getUri() ?>"
-                        class="underline hover:no-underline"
+                    md:px-0
+                    md:py-1
+                    md:inline
+                    md:text-base
+                    <?= $this->isCurrent($chapter) ? 'font-bold text-[--primary]' : '' ?>
+                    "
                 >
-                    Next: <?= $this->nextChapter()?->title ?>
+                  <?= $chapter->title ?>
                 </a>
+
+                <?php if ($this->isCurrent($chapter) && ($subChapters = $this->getSubChapters()) !== []): ?>
+                <div class="
+                  hidden
+                  md:grid
+                  md:border-r
+                  md:border-[--border]
+                  md:pr-2
+                  text-sm
+                  gap-2
+                  mr-2
+                  mt-2
+                  mb-4
+                  pt-2
+                  pb-2
+                ">
+                  <?php foreach ($subChapters as $url => $title): ?>
+                    <a href="<?= $url ?>" class="hover:text-[--primary] hover:underline text--[--foreground] transition">
+                      <?= $title ?>
+                    </a>
+                  <?php endforeach; ?>
+                </div>
+                <?php endif ?>
+              <?php } ?>
             </div>
-        </div>
+          <?php } ?>
+        </aside>
+      </div>
     </div>
+
+    <!-- Docs content -->
+    <div class="px-4 md:px-6 pt-8 md:col-span-9">
+      <?php if ($this->currentChapter) { ?>
+        <div class="prose dark:prose-invert">
+          <h1>
+            <?= $this->currentChapter->title ?>
+          </h1>
+          <?= $this->currentChapter->body ?>
+        </div>
+      <?php } ?>
+
+      <!-- Docs footer -->
+      <div class="bg-[--card] text-[--card-foreground] font-bold rounded-md p-4 flex justify-between gap-2 my-6">
+        <!-- Socials -->
+        <div class="flex gap-1">
+          <a href="https://github.com/tempestphp/tempest-framework" class="underline hover:no-underline">GitHub</a>
+          •
+          <a href="https://discord.gg/pPhpTGUMPQ" class="underline hover:no-underline">Discord</a>
+        </div>
+        <!-- Next chapter link -->
+        <a
+          :if="$this->nextChapter()"
+          href="<?= $this->nextChapter()?->getUri() ?>"
+          class="underline hover:no-underline"
+        >
+          Next: <?= $this->nextChapter()?->title ?>
+        </a>
+      </div>
+    </div>
+  </main>
 </x-base>

--- a/app/Front/code.css
+++ b/app/Front/code.css
@@ -1,188 +1,193 @@
 :root {
-    --background-color: #f3f3f3;
-    --text-color: #000;
-    --keyword-color: #4F95D1;
-    --property-color: #4CB966;
-    --type-color: #D14F57;
-    --generic-color: #9D3AF6;
-    --value-color: #515248;
-    --comment-color: #888888;
+	--code-background: #f3f3f3;
+	--code-foreground: #000000;
+	--code-keyword: #4f95d1;
+	--code-property: #4cb966;
+	--code-type: #d14f57;
+	--code-generic: #9d3af6;
+	--code-value: #515248;
+	--code-comment: #888888;
+	--code-highlight: #22dddd33;
+	--code-addition: #00ff0022;
+	--code-deletion: #ff000011;
+	--code-gutter: #555555;
+	--code-gutter-addition: #34a853;
+	--code-gutter-deletion: #ea4334;
+	--code-moderate: #fef9c3;
+	--code-complex: #fee2e2;
+	--code-adverb: #e0f2fe;
+	--code-passive: #dcfce7;
+	--code-complex-phrase: #f3e8ff;
+	--code-qualified: #f1f5f9;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--code-background: #1c1e26;
+		--code-foreground: #d5d8da;
+		--code-keyword: #e95678;
+		--code-property: #fab795;
+		--code-type: #25b0bc;
+		--code-generic: #b877db;
+		--code-value: #f09483;
+		--code-comment: #6c6f93;
+		--code-highlight: #2e303e;
+		--code-addition: #09f7a052;
+		--code-deletion: #f43e5c52;
+		--code-gutter: #6c6f93;
+		--code-gutter-addition: #27d796;
+		--code-gutter-deletion: #f43e5c;
+		--code-moderate: #fab38e33;
+		--code-complex: #e9567833;
+		--code-adverb: #21bfc280;
+		--code-passive: #b877db80;
+		--code-complex-phrase: #25b0bc33;
+		--code-qualified: #6c6f9333;
+	}
 }
 
 .prose pre {
-    background-color: var(--background-color);
-    color: var(--text-color);
-    max-width: 100%;
-    overflow-x: auto;
-    width: 100%;
+	background-color: var(--code-background);
+	color: var(--code-foreground);
+	max-width: 100%;
+	overflow-x: auto;
+	width: 100%;
 }
-
 
 .hl-keyword {
-    color: var(--keyword-color);
+	color: var(--code-keyword);
 }
-
 .hl-property {
-    color: var(--property-color);
+	color: var(--code-property);
 }
-
-/*.hl-attribute {*/
-/*    font-family: "Radon", serif;*/
-/*}*/
-
 .hl-type {
-    color: var(--type-color);
+	color: var(--code-type);
 }
-
 .hl-generic {
-    color: var(--generic-color);
+	color: var(--code-generic);
 }
-
 .hl-value {
-    color: var(--value-color);
+	color: var(--code-value);
 }
-
 .hl-comment {
-    color: var(--comment-color);
-    font-style: italic;
+	color: var(--code-comment);
+	font-style: italic;
 }
 
 .hl-blur {
-    filter: blur(2px);
+	filter: blur(2px);
 }
-
 .hl-strong {
-    font-weight: bold;
+	font-weight: bold;
 }
-
 .hl-em {
-    font-style: italic;
+	font-style: italic;
 }
 
 .hl-hl {
-    background-color: #22DDDD33;
-    display: inline-block;
-    line-height: 1.9em;
-    padding: 0 5px;
+	background-color: var(--code-highlight);
+	display: inline-block;
+	line-height: 1.9em;
+	padding: 0 5px;
 }
 
 .hl-console-underline {
-    text-decoration: underline;
+	text-decoration: underline;
 }
-
 .hl-console-strong {
-    font-weight: bold;
+	font-weight: bold;
 }
-
 .hl-console-comment {
-    color: #888888;
+	color: var(--code-comment);
+}
+.hl-console-em {
+	color: var(--code-keyword);
 }
 
-.hl-console-em {
-    color: #4F95D1;
+.hl-console-question,
+.hl-console-error,
+.hl-console-success,
+.hl-console-h1,
+.hl-console-h2 {
+	color: #fff;
+	display: inline-block;
+	line-height: 1.9em;
+	padding: 0 5px;
 }
 
 .hl-console-question {
-    background-color: #4F95D1;
-    color: #fff;
-    display: inline-block;
-    line-height: 1.9em;
-    padding: 0 5px;
+	background-color: var(--code-keyword);
 }
-
 .hl-console-error {
-    background-color: #D14F57;
-    color: #fff;
-    display: inline-block;
-    line-height: 1.9em;
-    padding: 0 5px;
+	background-color: var(--code-type);
 }
-
 .hl-console-success {
-    background-color: #4CB966;
-    color: #fff;
-    display: inline-block;
-    line-height: 1.9em;
-    padding: 0 5px;
+	background-color: var(--code-property);
 }
-
 .hl-console-h1 {
-    background-color: #4AB1D1;
-    color: #fff;
-    font-weight: bold;
-    display: inline-block;
-    line-height: 2em;
-    padding: 0 5px;
+	background-color: #4ab1d1;
+	font-weight: bold;
+	line-height: 2em;
 }
-
 .hl-console-h2 {
-    background-color: #4F95D1;
-    color: #fff;
-    display: inline-block;
-    line-height: 1.8em;
-    padding: 0 5px;
+	background-color: var(--code-keyword);
+	line-height: 1.8em;
 }
 
 .hl-a {
-    background-color: #FFFF0077;
+	background-color: #ffff0077;
 }
-
 .hl-b {
-    background-color: #FF00FF33;
+	background-color: #ff00ff33;
 }
 
 .hl-addition {
-    min-width: 100%;
-    background-color: #00FF0022;
+	min-width: 100%;
+	background-color: var(--code-addition);
 }
 
 .hl-deletion {
-    min-width: 100%;
-    background-color: #FF000011;
+	min-width: 100%;
+	background-color: var(--code-deletion);
 }
 
 .hl-gutter {
-    display: inline-block;
-    font-size: 0.9em;
-    color: #555;
-    padding: 0 1ch;
-    user-select: none;
+	display: inline-block;
+	font-size: 0.9em;
+	color: var(--code-gutter);
+	padding: 0 1ch;
+	user-select: none;
 }
 
 .hl-gutter-addition {
-    background-color: #34A853;
-    color: #fff;
+	background-color: var(--code-gutter-addition);
+	color: #fff;
 }
 
 .hl-gutter-deletion {
-    background-color: #EA4334;
-    color: #fff;
+	background-color: var(--code-gutter-deletion);
+	color: #fff;
 }
 
 .hl-moderate-sentence {
-    background-color: #fef9c3;
+	background-color: var(--code-moderate);
 }
-
 .hl-complex-sentence {
-    background-color: #fee2e2;
+	background-color: var(--code-complex);
 }
-
 .hl-adverb-phrase {
-    background-color: #e0f2fe;
+	background-color: var(--code-adverb);
 }
-
 .hl-passive-phrase {
-    background-color: #dcfce7;
+	background-color: var(--code-passive);
 }
-
 .hl-complex-phrase {
-    background-color: #f3e8ff;
+	background-color: var(--code-complex-phrase);
 }
-
 .hl-qualified-phrase {
-    background-color: #f1f5f9;
+	background-color: var(--code-qualified);
 }
 
-pre[data-lang="ellison"] {
-    text-wrap: wrap;
+pre[data-lang='ellison'] {
+	text-wrap: wrap;
 }

--- a/app/Front/main.css
+++ b/app/Front/main.css
@@ -1,76 +1,107 @@
-@import "code.css";
-@import "fonts.css";
+@import 'code.css';
+@import 'fonts.css';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+:root {
+	--background: #ffffff;
+	--foreground: #000000;
+	--card: #4e96d1;
+	--card-foreground: #ffffff;
+	--primary: #4f95d1;
+	--primary-foreground: #ffffff;
+	--link-color: #4f95d1;
+	--link-hover-color: var(--primary);
+	--code-background: #f3f3f3;
+	--border: var(--primary);
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--background: #121212;
+		--foreground: #cdd6f4;
+		--card: #1e1e1e;
+		--card-foreground: #cdd6f4;
+		--primary: #89b4fa;
+		--primary-foreground: #1e1e2e;
+		--link-color: #89b4fa;
+		--link-hover-color: var(--primary);
+		--code-background: #171717;
+		--border: transparent;
+	}
+}
+
+body:has(.docs) {
+	background-color: var(--background);
+	color: var(--foreground);
+}
+
+.prose a {
+	color: var(--link-color);
+}
+
+.prose a {
+	color: var(--link-hover-color);
+}
+
 div a.menu-link {
-    line-height: 1.4em;
+	line-height: 1.4em;
 }
 
 video {
-    width: 100%;
-    outline: none;
+	width: 100%;
+	outline: none;
 }
 
 video::-webkit-media-controls-panel {
-    background-image: none !important;
-    filter: brightness(0.4);
+	background-image: none !important;
+	filter: brightness(0.4);
 }
 
-h1, h2, h3, h4, h5, h6 {
-    & .heading-permalink {
-        display: none;
-    }
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	& .heading-permalink {
+		display: none;
+	}
 
-    &:hover .heading-permalink {
-        display: inline;
-    }
+	&:hover .heading-permalink {
+		display: inline;
+	}
 }
 
 @media (min-width: 800px) {
-    .slope {
-        clip-path: polygon(
-                0 0,
-                100% 0,
-                100% 100%,
-                0 calc(100% - 10vw)
-        );
-        position: relative;
-    }
+	.slope {
+		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 calc(100% - 10vw));
+		position: relative;
+	}
 
-    .slope-2 {
-        clip-path: polygon(
-                0 5%,
-                100% 0,
-                100% 100%,
-                0 95%
-        );
-        position: relative;
-    }
+	.slope-2 {
+		clip-path: polygon(0 5%, 100% 0, 100% 100%, 0 95%);
+		position: relative;
+	}
 
-    .slope-3 {
-        clip-path: polygon(
-                0 20%,
-                100% 0,
-                100% 100%,
-                0 100%
-        );
-        position: relative;
-    }
+	.slope-3 {
+		clip-path: polygon(0 20%, 100% 0, 100% 100%, 0 100%);
+		position: relative;
+	}
 }
 
 .header-gradient {
-    background: linear-gradient(135deg, #0171bc 0%, #1b1429 100%);
+	background: linear-gradient(135deg, #0171bc 0%, #1b1429 100%);
 }
 
 .tempest {
-    color: #1b1429;
-    font-weight: bold;
-    background: #29abe2;
-    padding: .3em .3em .2em;
-    border-radius: 5px;
-    font-family: Argon, monospace;
-    margin: 0 .1em;
+	color: #1b1429;
+	font-weight: bold;
+	background: #29abe2;
+	padding: 0.3em 0.3em 0.2em;
+	border-radius: 5px;
+	font-family: Argon, monospace;
+	margin: 0 0.1em;
 }

--- a/app/Front/main.css
+++ b/app/Front/main.css
@@ -38,6 +38,14 @@ body:has(.docs) {
 	color: var(--foreground);
 }
 
+.prose {
+	max-width: 80ch;
+}
+
+.prose h2 {
+	scroll-margin-top: 40px;
+}
+
 .prose a {
 	color: var(--link-color);
 }


### PR DESCRIPTION
This pull request adds support for automatic dark mode, only on the documentation section.

- The home page is unchanged (no dark mode), except for slight code highlighting changes (which are global)
- The original documentation light theme is unchanged
- I slightly improved the formatting on `docs.view.php` (indentation, element alignments, added a few comments for readability)
- I also moved the current chapters section to the right, for better readability

![CleanShot 2024-09-23 at 17 51 50](https://github.com/user-attachments/assets/24ef2058-b5f8-475c-a9f7-8d1b3f68702a)
