### PR TITLE
Update codeblock-home.view.php

### DIFF
--- a/app/Front/Components/codeblock-home.view.php
+++ b/app/Front/Components/codeblock-home.view.php
@@ -1,5 +1,5 @@
 <x-component name="x-codeblock-home">
-  <div class="overflow-x-scroll max-w-full grid gap-8 col-span-5 md:col-span-3 bg-white px-6 py-8 rounded-[9px] shadow-[0_0_0_1px_rgba(0,0,0,0.1)] text-[14px]">
+  <div class="overflow-x-auto max-w-full grid gap-8 col-span-5 md:col-span-3 bg-white px-6 py-8 rounded-[9px] shadow-[0_0_0_1px_rgba(0,0,0,0.1)] text-[14px]">
     <x-slot />
   </div>
 </x-component>


### PR DESCRIPTION
This removes the always-visible-and-disabled scrollbar on windows and replaces it with a scrollbar that only appears when the content can be scrolled.