### PR TITLE
Fix issues in alpha 2 blog post

### DIFF
--- a/app/Front/Blog/Content/2024-10-02-alpha-2.md
+++ b/app/Front/Blog/Content/2024-10-02-alpha-2.md
@@ -15,7 +15,7 @@ composer require tempest/framework:1.0-alpha2
 
 ## Authentication and Authorization
 
-Being able to log in and protect routes is a pretty important feature of any framework. For alpha 2, we've lain the groundwork to build upon: Tempest handles user sessions, and checks their permissions with a clean API:
+Being able to log in and protect routes is a pretty important feature of any framework. For alpha 2, we've laid the groundwork to build upon: Tempest handles user sessions, and checks their permissions with a clean API:
 
 ```php
 $authenticator->login($user);
@@ -73,7 +73,7 @@ By the way, we're always open for PRs that add more methods to these classes, so
 
 ## Cache
 
-We also added a cache component, which is a small wrapper around PSR-6. All PSR-6 compliant libraries can be plugged in, but we made the user-facing interface much simpler. I was inspired by an [awesome blogpost by Anthony Ferrera](https://blog.ircmaxell.com/2014/10/an-open-letter-to-php-fig.html), which talks about a cleaner approach to PSR-6 — a must-read!
+We also added a cache component, which is a small wrapper around [PSR-6](https://www.php-fig.org/psr/psr-6/). All PSR-6 compliant libraries can be plugged in, but we made the user-facing interface much simpler. I was inspired by an [awesome blogpost by Anthony Ferrera](https://blog.ircmaxell.com/2014/10/an-open-letter-to-php-fig.html), which talks about a cleaner approach to PSR-6 — a must-read!
 
 Here's what caching in Tempest looks like in a nutshell:
 
@@ -101,7 +101,7 @@ You can read all the details about caching [in the docs](/docs/framework/caching
 
 ## Discovery improvements
 
-Finally, we made a lot of bugfixes and performance improvements to [discovery](/docs/internals/discovery), one of Tempests most powerful features. Besides bugfixes, we've also started working on discovery more powerful, for example by allowing vendor classes to be hidden from discovery:
+Finally, we made a lot of bugfixes and performance improvements to [discovery](/docs/internals/discovery), one of Tempests most powerful features. Besides bugfixes, we've also started making discovery more powerful, for example by allowing vendor classes to be hidden from discovery:
 
 ```php
 
@@ -120,7 +120,7 @@ Of course, there are a lot more small things fixed, changed, and added. You can 
 
 So, what's next? We keep on working towards the next alpha version: Aidan's working on a filesystem component, Enzo works on that `#[CanBePublished]` attribute, Sergiu is working on extended regex support for routing, and I'll tackle async command handling.
 
-There's a lot going on, and we're super excited for it! Make sure to either [subscribe via RSS](http://tempest-docs.test/rss) or [join our Discord](https://tempestphp.com/discord) if you want to stay up-to-date! 
+There's a lot going on, and we're super excited for it! Make sure to either [subscribe via RSS](https://tempestphp.com/rss) or [join our Discord](https://tempestphp.com/discord) if you want to stay up-to-date! 
 
 Until next time
 


### PR DESCRIPTION
- Fixes typos
- Adds link to PSR-6
- Fixes grammar
- Links to the live RSS feed (instead of the `.test` one 😉)