### PR TITLE
feat: support searching through Algolia 

### DIFF
--- a/app/Front/Docs/docs.view.php
+++ b/app/Front/Docs/docs.view.php
@@ -2,13 +2,24 @@
 
 <x-base :title="$this->currentChapter->title">
   <!-- Banner -->
-  <div class="px-4 text-center py-4 bg-[--card] font-bold text-[--card-foreground] w-full z-[99] mb-4 flex items-center gap-2 justify-center">
+  <div class="dark px-4 text-center py-4 bg-[--card] font-bold text-[--card-foreground] w-full z-[99] mb-4 flex items-center gap-2 justify-center">
     <img src="/favicon/favicon-32x32.png" alt="favicon" class="h-[20px] hidden md:inline-block">
     <span>
       Tempest is still a <span class="hl-attribute">work in progress</span>. Visit our <a href="https://github.com/tempestphp/tempest-framework/issues" class="underline hover:no-underline">GitHub</a> or
       <a href="https://discord.gg/pPhpTGUMPQ" class="underline hover:no-underline">Discord</a>
     </span>
+    <div id="docsearch"></div>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        window.docsearch({
+            container: '#docsearch',
+            appId: 'WCE34U42S7',
+            indexName: 'tempestphp',
+            apiKey: '9bf1ba721d34be73279c688e50e94472',
+        })
+    })
+  </script>
   <!-- Toggling menu -->
   <script>
     function toggleMenu() {

--- a/app/Front/base.view.php
+++ b/app/Front/base.view.php
@@ -28,9 +28,10 @@ use App\Front\Meta\MetaType;
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
         <x-slot name="styles"/>
-        <link href="/main.css" rel="stylesheet">
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=source-code-pro:500|archivo:700,900" rel="stylesheet"/>
+        <link href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" rel="stylesheet"/>
+        <link href="/main.css" rel="stylesheet">
 
         <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png">
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png">
@@ -39,10 +40,9 @@ use App\Front\Meta\MetaType;
     </head>
 
     <body class="relative font-sans antialiased">
-
     <x-slot/>
-
     <x-slot name="scripts" />
+    <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
     </body>
 
     </html>

--- a/app/Front/main.css
+++ b/app/Front/main.css
@@ -1,76 +1,107 @@
-@import "code.css";
-@import "fonts.css";
+@import 'code.css';
+@import 'fonts.css';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-    --background: #ffffff;
-    --foreground: #000000;
-    --card: #4e96d1;
-    --card-foreground: #ffffff;
-    --primary: #4f95d1;
-    --primary-foreground: #ffffff;
-    --link-color: #4f95d1;
-    --link-hover-color: var(--primary);
-    --code-background: #f3f3f3;
-    --border: var(--primary);
+	--background: #ffffff;
+	--foreground: #000000;
+	--card: #4e96d1;
+	--card-foreground: #ffffff;
+	--primary: #4f95d1;
+	--primary-foreground: #ffffff;
+	--link-color: #4f95d1;
+	--link-hover-color: var(--primary);
+	--code-background: #f3f3f3;
+	--border: var(--primary);
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
-        --background: #121212;
-        --foreground: #cdd6f4;
-        --card: #1e1e1e;
-        --card-foreground: #cdd6f4;
-        --primary: #89b4fa;
-        --primary-foreground: #1e1e2e;
-        --link-color: #89b4fa;
-        --link-hover-color: var(--primary);
-        --code-background: #171717;
-        --border: transparent;
-    }
+	:root {
+		--background: #121212;
+		--foreground: #cdd6f4;
+		--card: #1e1e1e;
+		--card-foreground: #cdd6f4;
+		--primary: #89b4fa;
+		--primary-foreground: #1e1e2e;
+		--link-color: #89b4fa;
+		--link-hover-color: var(--primary);
+		--code-background: #171717;
+		--border: transparent;
 
-    /* TODO: this is a quickfix */
-    .prose, .prose h1, .prose h2 {
-        color: rgb(209, 213, 219);
-    }
+		/* Primary colors */
+		--docsearch-primary-color: #8ab4fa;
+		--docsearch-highlight-color: #8ab4fa;
+		--docsearch-text-color: #e4e4e4;
+		--docsearch-muted-color: #a0a0a0;
+
+		/* Searchbox styling */
+		--docsearch-searchbox-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+		--docsearch-searchbox-background: #1e1e1e;
+		--docsearch-searchbox-focus-background: #252525;
+
+		/* Key styling */
+		--docsearch-key-gradient: linear-gradient(to bottom, #2a2a2a, #222222);
+		--docsearch-key-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.4);
+
+		/* Modal and footer styling */
+		--docsearch-modal-background: #1a1a1a;
+		--docsearch-footer-background: #252525;
+		--docsearch-modal-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+		--docsearch-footer-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
+
+		/* Logo and hits styling */
+		--docsearch-logo-color: #8ab4fa;
+		--docsearch-hit-background: #252525;
+		--docsearch-hit-selected-background: #202020;
+		--docsearch-hit-color: #e4e4e4;
+		--docsearch-hit-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+	}
+
+	/* TODO: this is a quickfix */
+	.prose,
+	.prose h1,
+	.prose h2 {
+		color: rgb(209, 213, 219);
+	}
 }
 
-body:has(.docs), body:has(.blog) {
-    background-color: var(--background);
-    color: var(--foreground);
+body:has(.docs),
+body:has(.blog) {
+	background-color: var(--background);
+	color: var(--foreground);
 }
 
 .prose {
-    max-width: 80ch;
+	max-width: 80ch;
 }
 
 .prose h2 {
-    scroll-margin-top: 40px;
+	scroll-margin-top: 40px;
 }
 
 .prose a {
-    color: var(--link-color);
+	color: var(--link-color);
 }
 
 .prose a {
-    color: var(--link-hover-color);
+	color: var(--link-hover-color);
 }
 
 div a.menu-link {
-    line-height: 1.4em;
+	line-height: 1.4em;
 }
 
 video {
-    width: 100%;
-    outline: none;
+	width: 100%;
+	outline: none;
 }
 
 video::-webkit-media-controls-panel {
-    background-image: none !important;
-    filter: brightness(0.4);
+	background-image: none !important;
+	filter: brightness(0.4);
 }
 
 h1,
@@ -79,94 +110,95 @@ h3,
 h4,
 h5,
 h6 {
-    & .heading-permalink {
-        display: none;
-    }
+	& .heading-permalink {
+		display: none;
+	}
 
-    &:hover .heading-permalink {
-        display: inline;
-    }
+	&:hover .heading-permalink {
+		display: inline;
+	}
 }
 
 .tempest-logo {
-    border: 2px solid red;
+	border: 2px solid red;
 }
 
 .\@HeroBlock {
-    @apply bg-no-repeat bg-bottom;
-    background-image: linear-gradient(
-            to bottom,
-            #0071BCCC 20%,
-            #1B1429CC 100%
-    ),
-    linear-gradient(
-            to right,
-            #0071BC 0%,
-            rgba(0, 87, 190, 0%),
-            #0071BC 100%
-    ),
-    url("/img/bg-dark-theme-2@2x.jpg");
-    background-position: top;
-    background-color: #0071BC;
-    background-size: 100%, 1232px 100%, 1232px auto;
-    position: relative;
+	@apply bg-no-repeat bg-bottom;
+	background-image: linear-gradient(to bottom, #0071bccc 20%, #1b1429cc 100%),
+		linear-gradient(to right, #0071bc 0%, rgba(0, 87, 190, 0%), #0071bc 100%),
+		url('/img/bg-dark-theme-2@2x.jpg');
+	background-position: top;
+	background-color: #0071bc;
+	background-size: 100%, 1232px 100%, 1232px auto;
+	position: relative;
 }
 
 @media (min-width: 800px) {
-    .\@HeroBlock {
-        clip-path: polygon(0 0, 100% 0, 100% 100%, 0 85%);
-        /*clip-path: polygon(0 0, 100% 0, 100% 100%, 0 80px);*/
-        padding-bottom: 80px;
-    }
+	.\@HeroBlock {
+		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 85%);
+		/*clip-path: polygon(0 0, 100% 0, 100% 100%, 0 80px);*/
+		padding-bottom: 80px;
+	}
 
-    .slope {
-        clip-path: polygon(0 0, 100% 0, 100% 100%, 0 calc(100% - 24px));
-        position: relative;
-    }
+	.slope {
+		clip-path: polygon(0 0, 100% 0, 100% 100%, 0 calc(100% - 24px));
+		position: relative;
+	}
 
-    .slope-2 {
-        clip-path: polygon(0 24px, 100% 0, 100% 100%, 0 calc(100% - 24px));
-        position: relative;
-    }
+	.slope-2 {
+		clip-path: polygon(0 24px, 100% 0, 100% 100%, 0 calc(100% - 24px));
+		position: relative;
+	}
 
-    .slope-3 {
-        clip-path: polygon(0 0, 100% 24px, 100% 100%, 0 100%);
-        position: relative;
-    }
+	.slope-3 {
+		clip-path: polygon(0 0, 100% 24px, 100% 100%, 0 100%);
+		position: relative;
+	}
 
-    .slope-4 {
-        clip-path: polygon(0 0, 100% 24px, 100% calc(100% - 24px), 0 100%);
-        position: relative;
-    }
+	.slope-4 {
+		clip-path: polygon(0 0, 100% 24px, 100% calc(100% - 24px), 0 100%);
+		position: relative;
+	}
 }
 
 .header-gradient {
-    background: linear-gradient(135deg, #0171bc 0%, #1b1429 100%);
+	background: linear-gradient(135deg, #0171bc 0%, #1b1429 100%);
 }
 
 @media (min-width: 600px) {
-    .tempest {
-        color: #1b1429;
-        font-weight: bold;
-        background: #29abe2;
-        padding: 0.3em 0.3em 0.2em;
-        border-radius: 5px;
-        font-family: Argon, monospace;
-        margin: 0 0.1em;
-    }
+	.tempest {
+		color: #1b1429;
+		font-weight: bold;
+		background: #29abe2;
+		padding: 0.3em 0.3em 0.2em;
+		border-radius: 5px;
+		font-family: Argon, monospace;
+		margin: 0 0.1em;
+	}
 }
 
 .meta-image {
-    background-image: linear-gradient(
-            to bottom,
-            #0071BCCC 20%,
-            #1B1429CC 100%
-    ),
-    linear-gradient(
-            to right,
-            #0071BC 0%,
-            rgba(0, 87, 190, 0%),
-            #0071BC 100%
-    ),
-    url("/img/bg-dark-theme-2@2x.jpg");
+	background-image: linear-gradient(to bottom, #0071bccc 20%, #1b1429cc 100%),
+		linear-gradient(to right, #0071bc 0%, rgba(0, 87, 190, 0%), #0071bc 100%),
+		url('/img/bg-dark-theme-2@2x.jpg');
+}
+
+.DocSearch-Logo .cls-1,
+.DocSearch-Logo .cls-2 {
+	fill: var(--docsearch-logo-color) !important;
+}
+.DocSearch-Logo .cls-2 {
+	fill-rule: evenodd;
+}
+
+[class*='DocSearch'] .DocSearch-Hit a {
+	background-color: var(--docsearch-hit-background);
+}
+[class*='DocSearch'] .DocSearch-Hit[aria-selected='true'] a {
+	background-color: var(--docsearch-hit-selected-background);
+}
+
+.DocSearch-Input {
+	outline: none !important;
 }


### PR DESCRIPTION
Closes #29

This uses the CDN version of `@docsearch/js` to avoid pulling dependencies through npm, since there's no build pipeline right now.

I have done no effort on the layout: I just added the search to the existing banner, so refactoring will need to be done when this banner has to go


https://github.com/user-attachments/assets/744498f1-c31a-4eef-bf73-1dcc23362605

