### PR TITLE
Docs: fix broken link on controllers page

### DIFF
--- a/app/Front/Docs/Content/framework/03-controllers.md
+++ b/app/Front/Docs/Content/framework/03-controllers.md
@@ -226,7 +226,7 @@ If you're returning responses Tempest has a bunch of responses built-in:
 - `{php}Redirect` — the redirect response
 - `{php}ServerError` — a 500 server error response
 
-A full overview of responses can be found [here](https://github.com/tempestphp/tempest-framework/tree/main/src/Tempest/Http/Responses).
+A full overview of responses can be found [here](https://github.com/tempestphp/tempest-framework/tree/main/src/Tempest/Http/src/Responses).
 
 Returning responses from controllers looks like this:
 


### PR DESCRIPTION
Found a broken link to code repository on [controllers doc](https://tempestphp.com/docs/framework/controllers/#responses) 