### PR TITLE
docs: align code snippet and content in latest blog post

### DIFF
--- a/app/Front/Blog/Content/2024-11-08-unfair-advantage.md
+++ b/app/Front/Blog/Content/2024-11-08-unfair-advantage.md
@@ -98,7 +98,7 @@ final readonly class Make
 
 Which differences do you notice? 
 
-- Compare the verbose `configure()` method in Symfony, vs Laravel's `$definition` string, vs Tempest's approach. Which one feels the most natural? The only thing you need to know in Tempest is PHP. In Symfony you need a separate configure method and learn about the configuration API, while in Laravel you need to remember the textual syntax for the definition command. That's all unnecessary boilerplate. Tempest skips all the boilerplate, and figures out how to build a console definition for you based on the PHP parameters you actually need. That's what's meant when we say that "Tempest gets out of your way". The framework helps you, not the other way around.
+- Compare the verbose `configure()` method in Symfony, vs Laravel's `$signature` string, vs Tempest's approach. Which one feels the most natural? The only thing you need to know in Tempest is PHP. In Symfony you need a separate configure method and learn about the configuration API, while in Laravel you need to remember the textual syntax for the signature property. That's all unnecessary boilerplate. Tempest skips all the boilerplate, and figures out how to build a console definition for you based on the PHP parameters you actually need. That's what's meant when we say that "Tempest gets out of your way". The framework helps you, not the other way around.
 
 ```console
 ~ ./tempest


### PR DESCRIPTION
The code snippet showcasing an example Laravel command correctly uses the `$signature` property, but the accompanying content references a `$definition` property instead.

PS: this is a great blog post! keep up the good work with Tempest!