### PR TITLE
fix: update theme toggling in the footer

### DIFF
--- a/src/Web/x-footer.view.php
+++ b/src/Web/x-footer.view.php
@@ -27,7 +27,7 @@ use function Tempest\uri;
 
 	<script>
 	document.getElementById('toggle-theme').addEventListener('click', () => {
-		applyTheme(localStorage.theme === 'dark' ? 'light' : 'dark')
+		toggleDarkMode()
 	})
 	</script>
 </x-component>


### PR DESCRIPTION
In the currently implementation there's a bug (at least for me) in the toggle theme button in the footer.

When i open the site for the first time and it loads with my system's theme, so i click in the toggle theme button and nothing happens but the button state is changed, so i click again and it changes the website theme.

In this PR i'm using the `toggleDarkMode` function to change the theme


https://github.com/user-attachments/assets/1960394a-c265-44f9-8cc3-36c31cf54390

