### PR TITLE
chore: remove unnecessary parentheses as of PHP 8.4

### DIFF
--- a/src/Web/Blog/articles/2024-10-02-alpha-2.md
+++ b/src/Web/Blog/articles/2024-10-02-alpha-2.md
@@ -93,7 +93,7 @@ final readonly class RssController
             cache: function () {
                 return file_get_contents('https://stitcher.io/rss')
             },
-            expiresAt: (new DateTimeImmutable())->add(new DateInterval('P1D'))
+            expiresAt: new DateTimeImmutable()->add(new DateInterval('P1D'))
         );
     }
 }

--- a/src/Web/Blog/articles/2024-10-31-alpha-3.md
+++ b/src/Web/Blog/articles/2024-10-31-alpha-3.md
@@ -152,7 +152,7 @@ public function __invoke(): void
 ```php
 use Tempest\Generation\ClassManipulator;
 
-(new ClassManipulator(PackageMigration::class))
+new ClassManipulator(PackageMigration::class)
     ->removeClassAttribute(DoNotDiscover::class)
     ->setNamespace('App\\Migrations')
     ->print();

--- a/src/Web/Documentation/content/main/1-framework/02-the-container.md
+++ b/src/Web/Documentation/content/main/1-framework/02-the-container.md
@@ -62,7 +62,7 @@ final readonly class MarkdownInitializer implements Initializer
     {
         $environment = new Environment();
 
-        $highlighter = (new Highlighter(new CssTheme()));
+        $highlighter = new Highlighter(new CssTheme());
 
         $highlighter
             ->addLanguage(new TempestViewLanguage())

--- a/src/Web/Documentation/content/main/1-framework/03-controllers.md
+++ b/src/Web/Documentation/content/main/1-framework/03-controllers.md
@@ -282,7 +282,7 @@ final readonly class JsonController
     {
         $data = [ /* … */ ];
 
-        return (new Ok($data))->setContentType(ContentType::JSON);
+        return new Ok($data)->setContentType(ContentType::JSON);
     }
 }
 ```

--- a/src/Web/Documentation/content/main/1-framework/10-caching.md
+++ b/src/Web/Documentation/content/main/1-framework/10-caching.md
@@ -47,7 +47,7 @@ final readonly class RssController
             cache: function () {
                 return file_get_contents('https://stitcher.io/rss')
             },
-            expiresAt: (new DateTimeImmutable())->add(new DateInterval('P1D'))
+            expiresAt: new DateTimeImmutable()->add(new DateInterval('P1D'))
         )
     }
 }

--- a/src/Web/Documentation/content/main/1-framework/13-auth.md
+++ b/src/Web/Documentation/content/main/1-framework/13-auth.md
@@ -89,10 +89,10 @@ With this `User` model, you already have a lot of helper methods in place to bui
 ```php
 use App\Auth\User;
 
-$user = (new User(
+$user = new User(
     name: 'Brent',
     email: 'brendt@stitcher.io',
-))
+)
     ->setPassword('password')
     ->save()
     ->grantPermission('admin');

--- a/src/Web/Documentation/content/main/1-framework/15-primitive-utilities.md
+++ b/src/Web/Documentation/content/main/1-framework/15-primitive-utilities.md
@@ -12,7 +12,7 @@ The `ImmutableString` and `MutableString` classes wraps a normal string, and pro
 ```php
 use Tempest\Support\Str\ImmutableString;
 
-$slug = (new ImmutableString('https://tempestphp.com/docs/framework/14-primitive-helpers'))
+$slug = new ImmutableString('https://tempestphp.com/docs/framework/14-primitive-helpers')
     ->trim('/')
     ->afterLast('/')
     ->replaceRegex('/\d+-/', '')
@@ -40,7 +40,7 @@ The `ImmutableArray` and `MutableArray` classes wrap an array, and provide a flu
 ```php
 use Tempest\Support\Arr\ImmutableArray;
 
-$items = (new ImmutableArray(glob(__DIR__ . '/Content/*.md')))
+$items = new ImmutableArray(glob(__DIR__ . '/Content/*.md'))
     ->reverse()
     ->map(function (string $path) {
         // …

--- a/src/Web/Documentation/content/main/3-highlight/01-getting-started.md
+++ b/src/Web/Documentation/content/main/3-highlight/01-getting-started.md
@@ -40,7 +40,7 @@ You can build your own CSS theme with just a couple of classes, copy over [the b
 If you don't want to or can't load a CSS file, you can opt to use the `InlineTheme` class. This theme takes the path to a CSS file, and will parse it into inline styles:
 
 ```php
-$highlighter = (new Highlighter(new InlineTheme(__DIR__ . '/../src/Themes/Css/solarized-dark.css')));
+$highlighter = new Highlighter(new InlineTheme(__DIR__ . '/../src/Themes/Css/solarized-dark.css'));
 ```
 
 ### Terminal themes
@@ -63,7 +63,7 @@ echo $highlighter->parse($code, 'php');
 This package can render an optional gutter if needed.
 
 ```php
-$highlighter = (new Highlighter())->withGutter(startAt: 10);
+$highlighter = new Highlighter()->withGutter(startAt: 10);
 ```
 
 The gutter will show additions and deletions, and can start at any given line number:

--- a/src/Web/Homepage/codeblocks/markdown-initializer.md
+++ b/src/Web/Homepage/codeblocks/markdown-initializer.md
@@ -4,7 +4,7 @@ final readonly class MarkdownInitializer implements Initializer
     public function initialize(Container $container): MarkdownConverter
     {
         $environment = new Environment();
-        $highlighter = (new Highlighter(new CssTheme()));
+        $highlighter = new Highlighter(new CssTheme());
 
         $highlighter
             ->addLanguage(new TempestViewLanguage())


### PR DESCRIPTION
Since Tempest requires PHP 8.4, we can remove unnecessary parentheses.

However, the highlight component is still 8.3. Should I exclude it from the list of changes?