### PR TITLE
style: increased code block letter spacing

### DIFF
--- a/src/Web/Homepage/x-home-section.view.php
+++ b/src/Web/Homepage/x-home-section.view.php
@@ -1,6 +1,6 @@
 <x-component name="x-home-section">
 	<section class="mb-20 lg:mb-[7vh] flex justify-center flex-col tracking-tighter px-6">
-		<div class="grid grid-cols-1 lg:grid-cols-2 gap-x-12 items-center">
+		<div class="grid grid-cols-1 lg:grid-cols-2 items-center">
 			<!-- Left -->
 			<div class="p-2 lg:p-0">
 				<div class="max-w-xl text-sans">
@@ -19,7 +19,7 @@
 				</div>
 			</div>
 			<!-- Right -->
-			<div class="flex flex-col gap-2 p-2 text-sm bg-(--ui-bg)/20 rounded-xl">
+			<div class="flex flex-col gap-2 p-2 text-sm bg-(--ui-bg)/20 rounded-xl tracking-normal">
 				<div :foreach="$snippets as $snippet" class="bg-(--ui-bg)/50 border border-(--ui-border) rounded-md p-4 [&_pre]:h-full [&_pre]:overflow-x-auto">
 					{!! $codeBlocks[$snippet] !!}
 				</div>

--- a/src/Web/x-footer.view.php
+++ b/src/Web/x-footer.view.php
@@ -27,7 +27,7 @@ use function Tempest\uri;
 
 	<script>
 	document.getElementById('toggle-theme').addEventListener('click', () => {
-		applyTheme(localStorage.theme === 'dark' ? 'light' : 'dark')
+		toggleDarkMode()
 	})
 	</script>
 </x-component>


### PR DESCRIPTION
There's some changes in homepage code block letter spacing.

Before
![image](https://github.com/user-attachments/assets/a42b08ef-c05d-4265-a7aa-67376f462ab3)

After
![image](https://github.com/user-attachments/assets/46590ee6-8ac0-4f94-aac1-59d9c89d246f)
