### PR TITLE
docs: Migration Validation/Hashing

### DIFF
--- a/src/Web/Documentation/content/main/1-essentials/05-models.md
+++ b/src/Web/Documentation/content/main/1-essentials/05-models.md
@@ -206,7 +206,39 @@ A few [console commands](../3-console/02-building-console-commands) are provided
 
 {:hl-comment:# Drops all tables and rerun migrate:up:}
 ./tempest migrate:fresh
+
+{:hl-comment:# Validates the integrity of migration files:}
+./tempest migrate:validate
 ```
+
+#### Validating migrations
+
+The `migrate:validate` command checks the integrity of migration files by comparing their current hash with the stored hash in the database. If a migration file has been tampered with, the command will report it as a validation failure.
+
+```sh
+{:hl-comment:# Validate migration files:}
+./tempest migrate:validate
+```
+
+If any migration fails validation, it will be reported with an error message specifying the issue.
+
+:::info
+Only the actual SQL commands (minified and stripped of comments) are hashed during validation. This means that code-style changes, such as indentation or formatting, and comments will not impact the validation process.
+:::
+
+#### Using the `--validate` argument
+
+Both the `migrate:up` and `migrate:fresh` commands now support an optional `--validate` argument. When this argument is provided, the commands will first validate the migration files using `migrate:validate` before proceeding. If validation fails, the migration process will stop.
+
+```sh
+{:hl-comment:# Run migrations with validation:}
+./tempest migrate:up --validate
+
+{:hl-comment:# Drop all tables and rerun migrations with validation:}
+./tempest migrate:fresh --validate
+```
+
+This ensures that only valid, untampered migration files are applied to the database.
 
 ## Database configuration
 

--- a/src/Web/Documentation/content/main/1-essentials/05-models.md
+++ b/src/Web/Documentation/content/main/1-essentials/05-models.md
@@ -240,6 +240,15 @@ Both the `migrate:up` and `migrate:fresh` commands now support an optional `--va
 
 This ensures that only valid, untampered migration files are applied to the database.
 
+:::warning Rehashing Migrations
+
+The `migrate:rehash` command bypasses integrity checks to update stored migration hashes in the database. This operation can mask serious issues like tampered migration files or schema inconsistencies. Only use this command when absolutely necessary and when you're completely confident that your migration files are correct and consistent across environments.
+
+```sh
+./tempest migrate:rehash
+```
+:::
+
 ## Database configuration
 
 By default, Tempest uses a SQLite database stored in the `vendor/.tempest` directory. Changing databases is done by providing a {`Tempest\Database\Config\DatabaseConfig`} [configuration object](./06-configuration).

--- a/src/Web/Documentation/content/main/1-essentials/05-models.md
+++ b/src/Web/Documentation/content/main/1-essentials/05-models.md
@@ -211,7 +211,13 @@ A few [console commands](../3-console/02-building-console-commands) are provided
 ./tempest migrate:validate
 ```
 
-#### Validating migrations
+### Validating migrations
+
+:::warning
+All `migrate:up` and `migrate:fresh` commands validate migration files to ensure their integrity by default.
+
+If you don't want to validate migration files, you can use the `--no-validate` argument.
+:::
 
 The `migrate:validate` command checks the integrity of migration files by comparing their current hash with the stored hash in the database. If a migration file has been tampered with, the command will report it as a validation failure.
 
@@ -226,28 +232,19 @@ If any migration fails validation, it will be reported with an error message spe
 Only the actual SQL commands (minified and stripped of comments) are hashed during validation. This means that code-style changes, such as indentation or formatting, and comments will not impact the validation process.
 :::
 
-#### Using the `--validate` argument
+##### Rehashing Migrations
 
-Both the `migrate:up` and `migrate:fresh` commands now support an optional `--validate` argument. When this argument is provided, the commands will first validate the migration files using `migrate:validate` before proceeding. If validation fails, the migration process will stop.
+The `migrate:rehash` command bypasses integrity checks to update stored migration hashes in the database.
 
-```sh
-{:hl-comment:# Run migrations with validation:}
-./tempest migrate:up --validate
+:::warning
+This operation can mask serious issues like tampered migration files or schema inconsistencies.
 
-{:hl-comment:# Drop all tables and rerun migrations with validation:}
-./tempest migrate:fresh --validate
-```
-
-This ensures that only valid, untampered migration files are applied to the database.
-
-:::warning Rehashing Migrations
-
-The `migrate:rehash` command bypasses integrity checks to update stored migration hashes in the database. This operation can mask serious issues like tampered migration files or schema inconsistencies. Only use this command when absolutely necessary and when you're completely confident that your migration files are correct and consistent across environments.
+Only use this command when absolutely necessary and when you're confident that your migration files are correct and consistent across environments.
+:::
 
 ```sh
 ./tempest migrate:rehash
 ```
-:::
 
 ## Database configuration
 


### PR DESCRIPTION
Adds documentation for the `migrate:validate` command as well as mentions to the `--validate` argument available for `migrate:up` and `migrate:fresh`.

> [!NOTE]
> Related framework PR: https://github.com/tempestphp/tempest-framework/pull/1054


**Screenshot:** 
![image](https://github.com/user-attachments/assets/f2b19df6-082e-4601-b2a8-3d3349662727)


