### PR TITLE
Update migration example (because specifying an explicit default value on readonly properties is not allowed)

### DIFF
--- a/src/Web/Documentation/content/main/1-essentials/03-database.md
+++ b/src/Web/Documentation/content/main/1-essentials/03-database.md
@@ -395,7 +395,9 @@ use Tempest\Database\QueryStatements\DropTableStatement;
 
 final readonly class CreateBookTable implements DatabaseMigration
 {
-    public string $name = '2024-08-12_create_book_table';
+    public function __construct(
+        public string $name = '2024-08-12_create_book_table'
+    ) {}
 
     public function up(): QueryStatement|null
     {


### PR DESCRIPTION
Refactor the CreateBookTable migration to use constructor property promotion for the migration name

This pull request aligns the migration classes (example) PHP’s readonly-property rules. 

See [Doku](https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.readonly-properties):

## Note:

Specifying an explicit default value on readonly properties is not allowed, because a readonly property with a default value is essentially the same as a constant, and thus not particularly useful. 

```php

<?php

class Test {
    // Fatal error: Readonly property Test::$prop cannot have default value
    public readonly int $prop = 42;
}
?>
```