### PR TITLE
fix: redirects for `/console` and `/view`

### DIFF
--- a/src/Web/Homepage/HomeController.php
+++ b/src/Web/Homepage/HomeController.php
@@ -32,12 +32,12 @@ final readonly class HomeController
     #[Get('/view')]
     public function viewRedirect(): Redirect
     {
-        return new Redirect('/main/framework/views');
+        return new Redirect('/current/essentials/views');
     }
 
     #[Get('/console')]
     public function consoleRedirect(): Redirect
     {
-        return new Redirect('/main/console/getting-started');
+        return new Redirect('current/packages/console');
     }
 }


### PR DESCRIPTION
I was looking at the https://github.com/tempestphp/tempest-console repository and the link to the docs in the readme resulted in a 404.

Hopefully this PR will fix the outdated redirects.