### PR TITLE
feat(database): migration doc update/fix

### DIFF
--- a/src/GitHub/GetLatestRelease.php
+++ b/src/GitHub/GetLatestRelease.php
@@ -34,8 +34,8 @@ final class GetLatestRelease
                         ->body;
 
                     return json_decode($body)->tag_name ?? null;
-                }
-            )  ?? $defaultRelease;
+                },
+            ) ?? $defaultRelease;
         } catch (Throwable) {
             return $defaultRelease;
         }

--- a/src/Web/Code/CodeController.php
+++ b/src/Web/Code/CodeController.php
@@ -52,7 +52,6 @@ final readonly class CodeController
 
         $language = $request->get('lang') ?? 'php';
 
-
         $highlightedCode = $highlighter->parse(urldecode(base64_decode($code, strict: true)), $language);
 
         $center = $request->has('center');

--- a/src/Web/Documentation/content/1.x/1-essentials/03-database.md
+++ b/src/Web/Documentation/content/1.x/1-essentials/03-database.md
@@ -435,7 +435,6 @@ final class CreateBookTable implements DatabaseMigration
             ->text('title')
             ->datetime('created_at')
             ->datetime('published_at', nullable: true)
-            ->integer('author_id', unsigned: true)
             ->belongsTo('books.author_id', 'authors.id');
     }
 


### PR DESCRIPTION
I was setting up a dummy project, so I used the migration from the docs. Turns out that it fails because there was both an `integer(..)` as an `belongsTo(..)` defined for the `author_id`.

Removed the `integer(..)` from the docs, I assumed that the `belongsTo(..)` needs to stay :)