### PR TITLE
chore: redirect /main prefix

### DIFF
--- a/src/Web/Documentation/ChapterController.php
+++ b/src/Web/Documentation/ChapterController.php
@@ -20,6 +20,7 @@ final readonly class ChapterController
 {
     #[Get('/docs/{path:.*}')]
     #[Get('/current/{path:.*}')]
+    #[Get('/main/{path:.*}')]
     public function docsRedirect(string $path): Redirect
     {
         return new Redirect(sprintf('/%s/%s', Version::default()->value, $path));


### PR DESCRIPTION
I stumbled upon a google entry which was showing me a 500 error, added an additional redirect for the /main prefix on the docs page

this link is showing me a 500 error: https://tempestphp.com/main/features/logging
![image](https://github.com/user-attachments/assets/46d1d9e3-e454-4869-818a-edf13e884135)
