### PR TITLE
fix: address caster return type typo

### DIFF
--- a/src/Web/Documentation/content/1.x/2-features/01-mapper.md
+++ b/src/Web/Documentation/content/1.x/2-features/01-mapper.md
@@ -173,7 +173,7 @@ use Tempest\Mapper\Caster;
 
 final readonly class AddressCaster implements Caster
 {
-    public function cast(mixed $input): DateTimeInterface
+    public function cast(mixed $input): Address
     {
         return new Address(
             street: $input['street'],


### PR DESCRIPTION
Fixed typo. The return type of the Caster should be of type Address not type DateTimeInterface