### PR TITLE
docs: add validation rules

### DIFF
--- a/src/Web/Documentation/content/1.x/6-validation-rules/01-validation-rules.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/01-validation-rules.md
@@ -1,0 +1,80 @@
+---
+title: Validation Rules
+---
+
+## Overview
+
+Tempest's validation rules are located in the `Tempest\Validation\Rules` namespace and can be used as attributes on class properties. For detailed information on how to use validation rules, see the [Validation documentation](../2-features/03-validation.md#adding-more-rules).
+
+## Available rules
+
+Tempest provides a comprehensive set of validation rules that can be used with attributes on your class properties. Below is a complete list organized by category:
+
+### String Validation
+
+- **[Alpha](03-alpha.md)** - Validate that a value contains only alphabetic characters
+- **[AlphaNumeric](04-alpha-numeric.md)** - Validate that a value contains only alphanumeric characters
+- **[DoesNotEndWith](12-does-not-end-with.md)** - Validate that a value does not end with a specific string
+- **[DoesNotStartWith](13-does-not-start-with.md)** - Validate that a value does not start with a specific string
+- **[EndsWith](15-ends-with.md)** - Validate that a value ends with a specific string
+- **[IsString](26-is-string.md)** - Validate that a value is a string
+- **[Length](28-length.md)** - Validate the length of a string
+- **[Lowercase](29-lowercase.md)** - Validate that a string is lowercase
+- **[NotEmpty](32-not-empty.md)** - Validate that a string is not empty
+- **[Numeric](35-numeric.md)** - Validate that a value contains only numeric characters
+- **[RegEx](39-reg-ex.md)** - Validate that a value matches a regular expression
+- **[StartsWith](42-starts-with.md)** - Validate that a value starts with a specific string
+- **[Uppercase](47-uppercase.md)** - Validate that a string is uppercase
+
+### Numeric Validation
+
+- **[Between](07-between.md)** - Validate that a value is between a minimum and maximum value
+- **[DivisibleBy](11-divisible-by.md)** - Validate that a value is divisible by a specific number
+- **[Even](16-even.md)** - Validate if the value is an even number
+- **[IsFloat](24-is-float.md)** - Validate that a value is a float
+- **[IsInteger](25-is-integer.md)** - Validate that a value is an integer
+- **[MultipleOf](31-multiple-of.md)** - Validate that a value is a multiple of a specific number
+- **[Odd](36-odd.md)** - Validate if the value is an odd number
+
+### Date & Time Validation
+
+- **[AfterDate](02-after-date.md)** - Validate that a date is after a specific date
+- **[BeforeDate](06-before-date.md)** - Validate that a date is before a specific date
+- **[BetweenDates](08-between-dates.md)** - Validate that a date is between two other dates
+- **[DateTimeFormat](10-date-time-format.md)** - Validate that a value is a date in a specific format
+- **[Time](43-time.md)** - Validate that a value is a valid time
+- **[Timestamp](44-timestamp.md)** - Validate that a value is a valid timestamp
+- **[Timezone](45-timezone.md)** - Validate that a value is a valid timezone
+
+### Array & Collection Validation
+
+- **[ArrayList](05-array-list.md)** - Validate that a value is an array list
+- **[Count](09-count.md)** - Validate the number of items in an array
+- **[In](18-in.md)** - Validate that a value is one of a given set of values
+- **[NotIn](33-not-in.md)** - Validate that a value is not one of a given set of values
+
+### Network & Format Validation
+
+- **[Email](14-email.md)** - Validate that a value is a valid email address
+- **[HexColor](17-hex-color.md)** - Validate that a value is a valid hexadecimal color
+- **[IP](19-ip.md)** - Validate that a value is a valid IP address
+- **[IPv4](20-ipv4.md)** - Validate that a value is a valid IPv4 address
+- **[IPv6](21-ipv6.md)** - Validate that a value is a valid IPv6 address
+- **[Json](27-json.md)** - Validate that a value is a valid JSON string
+- **[MACAddress](30-macaddress.md)** - Validate that a value is a valid MAC address
+- **[PhoneNumber](38-phone-number.md)** - Validate that a value is a valid phone number
+- **[Ulid](46-ulid.md)** - Validate that a value is a valid ULID
+- **[Url](48-url.md)** - Validate that a value is a valid URL
+- **[Uuid](49-uuid.md)** - Validate that a value is a valid UUID
+
+### Type & Value Validation
+
+- **[IsBoolean](22-is-boolean.md)** - Validate that a value is a boolean
+- **[IsEnum](23-is-enum.md)** - Validate that a value is a valid case for a given enum
+- **[NotNull](34-not-null.md)** - Validate that a value is not null
+- **[ShouldBeFalse](40-should-be-false.md)** - Validate that a value is false
+- **[ShouldBeTrue](41-should-be-true.md)** - Validate that a value is true
+
+### Security Validation
+
+- **[Password](37-password.md)** - Validate that a string is a valid password

--- a/src/Web/Documentation/content/1.x/6-validation-rules/02-after-date.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/02-after-date.md
@@ -1,0 +1,58 @@
+---
+title: AfterDate
+description: "Validate that a date is after a specific date."
+---
+
+## Overview
+
+This rule validates whether a given date value is after a specified date. You can also choose to include the specified date in the validation.
+
+## Parameters
+
+- `$date` (`DateTimeInterface|DateTimeImmutable|string`): The date to compare against. Defaults to `now`.
+- `$inclusive` (`bool`): Whether to include the specified date in the validation. Defaults to `false`.
+
+## Examples
+
+### After a specific date
+
+```php
+use DateTimeImmutable;
+use Tempest\Validation\Rules\AfterDate;
+use Tempest\DateTime\DateTime;
+
+final class Book
+{
+    #[AfterDate('2023-01-01')]
+    public DateTime $fooDate;
+
+    #[AfterDate(new DateTime('2023-01-01'))]
+    public DateTime $barDate;
+
+    #[AfterDate(new DateTimeImmutable('2023-01-01'))]
+        public DateTime $bazDate;
+}
+```
+
+### After a specific date (inclusive)
+
+```php
+use Tempest\Validation\Rules\AfterDate;
+
+final class Book
+{
+    #[AfterDate('2023-01-01', inclusive: true)]
+    public DateTime $fooDate;
+
+    #[AfterDate(new DateTime('2023-01-01'), inclusive: true)]
+    public DateTime $barDate;
+
+    #[AfterDate(new DateTimeImmutable('2023-01-01'), inclusive: true)]
+    public DateTime $bazDate;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\BeforeDate](06-before-date.md)
+- [Tempest\Validation\Rules\BetweenDates](08-between-dates.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/03-alpha.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/03-alpha.md
@@ -1,0 +1,24 @@
+---
+title: Alpha
+description: "Validate that a value contains only alphabetic characters."
+---
+
+## Overview
+
+This rule validates whether a given string value contains only alphabetic characters (A-Z, a-z).
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Alpha;
+
+final class User
+{
+    #[Alpha()]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\AlphaNumeric](04-alpha-numeric.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/04-alpha-numeric.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/04-alpha-numeric.md
@@ -1,0 +1,24 @@
+---
+title: AlphaNumeric
+description: "Validate that a value contains only alphanumeric characters."
+---
+
+## Overview
+
+This rule validates whether a given string value contains only alphanumeric characters (A-Z, a-z, 0-9).
+
+## Example
+
+```php
+use Tempest\Validation\Rules\AlphaNumeric;
+
+final class User
+{
+    #[AlphaNumeric()]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Alpha](03-alpha.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/05-array-list.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/05-array-list.md
@@ -1,0 +1,20 @@
+---
+title: ArrayList
+description: "Validate that a value is an array list."
+---
+
+## Overview
+
+This rule validates whether a given value is an array list (a non-associative array).
+
+## Example
+
+```php
+use Tempest\Validation\Rules\ArrayList;
+
+final class Post
+{
+    #[ArrayList]
+    public array $tags;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/06-before-date.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/06-before-date.md
@@ -1,0 +1,57 @@
+---
+title: BeforeDate
+description: "Validate that a date is before a specific date."
+---
+
+## Overview
+
+This rule validates whether a given date value is before a specified date. You can also choose to include the specified date in the validation.
+
+## Parameters
+
+- `$date` (`DateTimeInterface|DateTimeImmutable|string`): The date to compare against. Defaults to `now`.
+- `$inclusive` (`bool`): Whether to include the specified date in the validation. Defaults to `false`.
+
+## Examples
+
+### Before a specific date
+
+```php
+use Tempest\Validation\Rules\BeforeDate;
+use Tempest\DateTime\DateTime;
+
+final class Book
+{
+    #[BeforeDate('2023-01-01')]
+    public DateTime $fooDate;
+
+    #[BeforeDate(new DateTime('2023-01-01'))]
+    public DateTime $barDate;
+
+    #[BeforeDate(new DateTimeImmutable('2023-01-01'))]
+    public DateTime $bazDate;
+}
+```
+
+### Before a specific date (inclusive)
+
+```php
+use Tempest\Validation\Rules\BeforeDate;
+
+final class Book
+{
+    #[BeforeDate('2023-01-01', inclusive: true)]
+    public DateTime $fooDate;
+
+    #[BeforeDate(new DateTime('2023-01-01'), inclusive: true)]
+    public DateTime $barDate;
+
+    #[BeforeDate(new DateTimeImmutable('2023-01-01'), inclusive: true)]
+    public DateTime $bazDate;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\AfterDate](02-after-date.md)
+- [Tempest\Validation\Rules\BetweenDates](08-between-dates.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/07-between.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/07-between.md
@@ -1,0 +1,30 @@
+---
+title: Between
+description: "Validate that a value is between a minimum and maximum value."
+---
+
+## Overview
+
+This rule validates whether a given numeric value is between a specified minimum and maximum value (inclusive).
+
+## Parameters
+
+- `$min` (`int`): The minimum allowed value.
+- `$max` (`int`): The maximum allowed value.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Between;
+
+final class Product
+{
+    #[Between(min: 1, max: 100)]
+    public int $stock;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Count](09-count.md)
+- [Tempest\Validation\Rules\Length](28-length.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/08-between-dates.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/08-between-dates.md
@@ -1,0 +1,58 @@
+---
+title: BetweenDates
+description: "Validate that a date is between two other dates."
+---
+
+## Overview
+
+This rule validates whether a given date value is between two other dates. You can specify whether the start and end dates should be included in the validation.
+
+## Parameters
+
+- `$first` (`DateTimeInterface|DateTimeImmutable|string`): The first date.
+- `$second` (`DateTimeInterface|DateTimeImmutable|string`): The second date.
+- `$inclusive` (`bool`): Whether to include the start and end dates in the validation. Defaults to `false`.
+
+## Examples
+
+### Between two dates (exclusive)
+
+```php
+use DateTimeImmutable;
+use Tempest\Validation\Rules\BetweenDates;
+use Tempest\DateTime\DateTime;
+final class Event
+{
+    #[BetweenDates('2023-01-01', '2023-12-31')]
+    public DateTime $fooDate;
+
+    #[BetweenDates(new DateTime('2023-01-01'), new DateTime('2023-12-31'))]
+    public DateTime $barDate;
+
+    #[BetweenDates(new DateTimeImmutable('2023-01-01'), new DateTimeImmutable('2023-12-31'))]
+    public DateTime $bazDate;
+}
+```
+
+### Between two dates (inclusive)
+
+```php
+use Tempest\Validation\Rules\BetweenDates;
+
+final class Event
+{
+    #[BetweenDates('2023-01-01', '2023-12-31', inclusive: true)]
+    public DateTime $fooDate;
+
+    #[BetweenDates(new DateTime('2023-01-01'), new DateTime('2023-12-31'), inclusive: true)]
+    public DateTime $barDate;
+
+    #[BetweenDates(new DateTimeImmutable('2023-01-01'), new DateTimeImmutable('2023-12-31'), inclusive: true)]
+    public DateTime $bazDate;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\AfterDate](02-after-date.md)
+- [Tempest\Validation\Rules\BeforeDate](06-before-date.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/09-count.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/09-count.md
@@ -1,0 +1,56 @@
+---
+title: Count
+description: "Validate the number of items in an array."
+---
+
+## Overview
+
+This rule validates the number of items in an array. You can specify a minimum, a maximum, or both.
+
+## Parameters
+
+- `$min` (`?int`): The minimum number of items allowed. Defaults to `null`.
+- `$max` (`?int`): The maximum number of items allowed. Defaults to `null`.
+
+## Examples
+
+### Minimum number of items
+
+```php
+use Tempest\Validation\Rules\Count;
+
+final class Cart
+{
+    #[Count(min: 1)]
+    public array $items;
+}
+```
+
+### Maximum number of items
+
+```php
+use Tempest\Validation\Rules\Count;
+
+final class Cart
+{
+    #[Count(max: 10)]
+    public array $items;
+}
+```
+
+### Between a minimum and maximum number of items
+
+```php
+use Tempest\Validation\Rules\Count;
+
+final class Cart
+{
+    #[Count(min: 1, max: 10)]
+    public array $items;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Between](07-between.md)
+- [Tempest\Validation\Rules\Length](28-length.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/10-date-time-format.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/10-date-time-format.md
@@ -1,0 +1,44 @@
+---
+title: DateTimeFormat
+description: "Validate that a value is a date in a specific format."
+---
+
+## Overview
+
+This rule validates whether a given string value is a date in a specific format. The format can be an ICU or legacy datetime format.
+
+## Parameters
+
+- `$format` (`string|FormatPattern`): An ICU or legacy datetime format.
+
+## Examples
+
+### Using a PHP date format
+
+```php
+use Tempest\Validation\Rules\DateTimeFormat;
+
+final class Event
+{
+    #[DateTimeFormat('Y-m-d H:i:s')]
+    public string $startTime;
+}
+```
+
+### Using a FormatPattern
+
+```php
+use Tempest\Validation\Rules\DateTimeFormat;
+use Tempest\DateTime\FormatPattern;
+
+final class Event
+{
+    #[DateTimeFormat(FormatPattern::JAVASCRIPT)]
+    public string $startTime;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Time](43-time.md)
+- [Tempest\Validation\Rules\Timestamp](44-timestamp.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/11-divisible-by.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/11-divisible-by.md
@@ -1,0 +1,28 @@
+---
+title: DivisibleBy
+description: "Validate that a value is divisible by a specific number."
+---
+
+## Overview
+
+This rule validates whether a given numeric value is divisible by a specific number.
+
+## Parameters
+
+- `$divisor` (`int`): The number by which the value must be divisible.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\DivisibleBy;
+
+final class Number
+{
+    #[DivisibleBy(2)]
+    public int $value;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\MultipleOf](31-multiple-of.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/12-does-not-end-with.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/12-does-not-end-with.md
@@ -1,0 +1,29 @@
+---
+title: DoesNotEndWith
+description: "Validate that a value does not end with a specific string."
+---
+
+## Overview
+
+This rule validates whether a given string value does not end with a specific string.
+
+## Parameters
+
+- `$needle` (`string`): The string that the value must not end with.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\DoesNotEndWith;
+
+final class File
+{
+    #[DoesNotEndWith('.tmp')]
+    public string $filename;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\EndsWith](15-ends-with.md)
+- [Tempest\Validation\Rules\DoesNotStartWith](13-does-not-start-with.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/13-does-not-start-with.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/13-does-not-start-with.md
@@ -1,0 +1,29 @@
+---
+title: DoesNotStartWith
+description: "Validate that a value does not start with a specific string."
+---
+
+## Overview
+
+This rule validates whether a given string value does not start with a specific string.
+
+## Parameters
+
+- `$needle` (`string`): The string that the value must not start with.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\DoesNotStartWith;
+
+final class User
+{
+    #[DoesNotStartWith('admin_')]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\StartsWith](42-starts-with.md)
+- [Tempest\Validation\Rules\DoesNotEndWith](12-does-not-end-with.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/14-email.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/14-email.md
@@ -1,0 +1,39 @@
+---
+title: Email
+description: "Validate that a value is a valid email address."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid email address according to RFC 5322.
+
+## Parameters
+
+- `$validationMethod` (`Egulias\EmailValidator\Validation\EmailValidation`): The validation method to use. Defaults to `new RFCValidation()`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\Email;
+
+final class User
+{
+    #[Email()]
+    public string $email;
+}
+```
+
+### With validation method
+
+```php
+use Tempest\Validation\Rules\Email;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
+
+final class User
+{
+    #[Email(validationMethod: new DNSCheckValidation())]
+    public string $email;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/15-ends-with.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/15-ends-with.md
@@ -1,0 +1,29 @@
+---
+title: EndsWith
+description: "Validate that a value ends with a specific string."
+---
+
+## Overview
+
+This rule validates whether a given string value ends with a specific string.
+
+## Parameters
+
+- `$needle` (`string`): The string that the value must end with.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\EndsWith;
+
+final class File
+{
+    #[EndsWith('.css')]
+    public string $filename;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\DoesNotEndWith](12-does-not-end-with.md)
+- [Tempest\Validation\Rules\StartsWith](42-starts-with.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/16-even.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/16-even.md
@@ -1,0 +1,24 @@
+---
+title: Even
+description: "Validate if the value is an even number"
+---
+
+## Overview
+
+This rule validates if the value is an even numer.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Even;
+
+final class Book
+{
+    #[Even()]
+    public string $number;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Odd](36-odd.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/17-hex-color.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/17-hex-color.md
@@ -1,0 +1,38 @@
+---
+title: HexColor
+description: "Validate that a value is a valid hexadecimal color."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid hexadecimal color.
+
+## Parameters
+
+- `$orNull` (`bool`): Whether to allow `null` values. Defaults to `false`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\HexColor;
+
+final class Design
+{
+    #[HexColor()]
+    public string $primaryColor;
+}
+```
+
+### Allow null values
+
+```php
+use Tempest\Validation\Rules\HexColor;
+
+final class Design
+{
+    #[HexColor(orNull: true)]
+    public ?string $primaryColor;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/18-in.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/18-in.md
@@ -1,0 +1,43 @@
+---
+title: In
+description: "Validate that a value is one of a given set of values."
+---
+
+## Overview
+
+This rule validates whether a given value is present in a given array of values.
+
+## Parameters
+
+- `$values` (`array<string|int>`): The array of values to check against.
+- `$not` (`bool`): If `true`, the rule validates that the value is *not* in the given array. Defaults to `false`.
+
+## Examples
+
+### In a set of values
+
+```php
+use Tempest\Validation\Rules\In;
+
+final class Shirt
+{
+    #[In(['S', 'M', 'L', 'XL'])]
+    public string $size;
+}
+```
+
+### Not in a set of values
+
+```php
+use Tempest\Validation\Rules\In;
+
+final class User
+{
+    #[In(['admin', 'root'], not: true)]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\NotIn](33-not-in.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/19-ip.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/19-ip.md
@@ -1,0 +1,56 @@
+---
+title: IP
+description: "Validate that a value is a valid IP address."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid IP address (either IPv4 or IPv6).
+
+## Parameters
+
+- `$allowPrivateRange` (`bool`): Whether to allow private IP ranges. Defaults to `true`.
+- `$allowReservedRange` (`bool`): Whether to allow reserved IP ranges. Defaults to `true`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\IP;
+
+final class Connection
+{
+    #[IP()]
+    public string $ipAddress;
+}
+```
+
+### Disallow private range
+
+```php
+use Tempest\Validation\Rules\IP;
+
+final class Connection
+{
+    #[IP(allowPrivateRange: false)]
+    public string $ipAddress;
+}
+```
+
+### Disallow reserved range
+
+```php
+use Tempest\Validation\Rules\IP;
+
+final class Connection
+{
+    #[IP(allowReservedRange: false)]
+    public string $ipAddress;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\IPv4](20-ipv4.md)
+- [Tempest\Validation\Rules\IPv6](21-ipv6.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/20-ipv4.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/20-ipv4.md
@@ -1,0 +1,56 @@
+---
+title: IPv4
+description: "Validate that a value is a valid IPv4 address."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid IPv4 address.
+
+## Parameters
+
+- `$allowPrivateRange` (`bool`): Whether to allow private IP ranges. Defaults to `true`.
+- `$allowReservedRange` (`bool`): Whether to allow reserved IP ranges. Defaults to `true`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\IPv4;
+
+final class Connection
+{
+    #[IPv4()]
+    public string $ipAddress;
+}
+```
+
+### Disallow private range
+
+```php
+use Tempest\Validation\Rules\IPv4;
+
+final class Connection
+{
+    #[IPv4(allowPrivateRange: false)]
+    public string $ipAddress;
+}
+```
+
+### Disallow reserved range
+
+```php
+use Tempest\Validation\Rules\IPv4;
+
+final class Connection
+{
+    #[IPv4(allowReservedRange: false)]
+    public string $ipAddress;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\IP](19-ip.md)
+- [Tempest\Validation\Rules\IPv6](21-ipv6.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/21-ipv6.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/21-ipv6.md
@@ -1,0 +1,56 @@
+---
+title: IPv6
+description: "Validate that a value is a valid IPv6 address."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid IPv6 address.
+
+## Parameters
+
+- `$allowPrivateRange` (`bool`): Whether to allow private IP ranges. Defaults to `true`.
+- `$allowReservedRange` (`bool`): Whether to allow reserved IP ranges. Defaults to `true`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\IPv6;
+
+final class Connection
+{
+    #[IPv6()]
+    public string $ipAddress;
+}
+```
+
+### Disallow private range
+
+```php
+use Tempest\Validation\Rules\IPv6;
+
+final class Connection
+{
+    #[IPv6(allowPrivateRange: false)]
+    public string $ipAddress;
+}
+```
+
+### Disallow reserved range
+
+```php
+use Tempest\Validation\Rules\IPv6;
+
+final class Connection
+{
+    #[IPv6(allowReservedRange: false)]
+    public string $ipAddress;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\IP](19-ip.md)
+- [Tempest\Validation\Rules\IPv4](20-ipv4.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/22-is-boolean.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/22-is-boolean.md
@@ -1,0 +1,41 @@
+---
+title: IsBoolean
+description: "Validate that a value is a boolean."
+---
+
+## Overview
+
+This rule validates whether a given value can be interpreted as a boolean. The values `true`, `'true'`, `1`, `'1'`, `false`, `'false'`, `0`, and `'0'` are all considered valid booleans.
+
+## Parameters
+
+- `$orNull` (`bool`): Whether to allow `null` values. Defaults to `false`.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\IsBoolean;
+
+final class Settings
+{
+    #[IsBoolean()]
+    public bool $darkMode;
+}
+```
+
+### Allow null values
+
+```php
+use Tempest\Validation\Rules\IsBoolean;
+
+final class Settings
+{
+    #[IsBoolean(orNull: true)]
+    public ?bool $darkMode;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\ShouldBeTrue](41-should-be-true.md)
+- [Tempest\Validation\Rules\ShouldBeFalse](40-should-be-false.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/23-is-enum.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/23-is-enum.md
@@ -1,0 +1,58 @@
+---
+title: IsEnum
+description: "Validate that a value is a valid case for a given enum."
+---
+
+## Overview
+
+This rule validates whether a given value is a valid case for a specific enum. You can also provide an array of cases to either include or exclude from validation.
+
+## Parameters
+
+- `$enum` (`string`): The enum class name.
+- `$only` (`array`): An array of enum cases that should be considered valid. Defaults to an empty array.
+- `$except` (`array`): An array of enum cases that should be considered invalid. Defaults to an empty array.
+
+## Examples
+
+```php
+use Tempest\Validation\Rules\IsEnum;
+
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
+
+final class Card
+{
+    #[IsEnum(Suit::class)]
+    public string $suit;
+}
+```
+
+### Only specific cases
+
+```php
+use Tempest\Validation\Rules\IsEnum;
+
+final class Card
+{
+    #[IsEnum(Suit::class, only: [Suit::Hearts, Suit::Clubs])]
+    public string $suit;
+}
+```
+
+### Except specific cases
+
+```php
+use Tempest\Validation\Rules\IsEnum;
+
+final class Card
+{
+    #[IsEnum(Suit::class, except: [Suit::Spades])]
+    public string $suit;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/24-is-float.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/24-is-float.md
@@ -1,0 +1,43 @@
+---
+title: IsFloat
+description: "Validate that a value is a float."
+---
+
+## Overview
+
+This rule validates whether a given value is a float.
+
+## Parameters
+
+- `$orNull` (`bool`): Whether to allow `null` values. Defaults to `false`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\IsFloat;
+
+final class Product
+{
+    #[IsFloat()]
+    public float $price;
+}
+```
+
+### Allow null values
+
+```php
+use Tempest\Validation\Rules\IsFloat;
+
+final class Product
+{
+    #[IsFloat(orNull: true)]
+    public ?float $price;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\IsInteger](25-is-integer.md)
+- [Tempest\Validation\Rules\Numeric](35-numeric.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/25-is-integer.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/25-is-integer.md
@@ -1,0 +1,43 @@
+---
+title: IsInteger
+description: "Validate that a value is an integer."
+---
+
+## Overview
+
+This rule validates whether a given value is an integer.
+
+## Parameters
+
+- `$orNull` (`bool`): Whether to allow `null` values. Defaults to `false`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\IsInteger;
+
+final class Product
+{
+    #[IsInteger()]
+    public int $quantity;
+}
+```
+
+### Allow null values
+
+```php
+use Tempest\Validation\Rules\IsInteger;
+
+final class Product
+{
+    #[IsInteger(orNull: true)]
+    public ?int $quantity;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\IsFloat](24-is-float.md)
+- [Tempest\Validation\Rules\Numeric](35-numeric.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/26-is-string.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/26-is-string.md
@@ -1,0 +1,38 @@
+---
+title: IsString
+description: "Validate that a value is a string."
+---
+
+## Overview
+
+This rule validates whether a given value is a string or a Stringable object.
+
+## Parameters
+
+- `$orNull` (`bool`): Whether to allow `null` values. Defaults to `false`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\IsString;
+
+final class User
+{
+    #[IsString()]
+    public string $name;
+}
+```
+
+### Allow null values
+
+```php
+use Tempest\Validation\Rules\IsString;
+
+final class User
+{
+    #[IsString(orNull: true)]
+    public ?string $name;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/27-json.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/27-json.md
@@ -1,0 +1,52 @@
+---
+title: Json
+description: "Validate that a value is a valid JSON string."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid JSON string.
+
+## Parameters
+
+- `$depth` (`?int`): The maximum depth to which the JSON structure should be parsed. Defaults to `null`.
+- `$flags` (`?int`): A bitmask of JSON constants. Defaults to `null`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\Json;
+
+final class Data
+{
+    #[Json()]
+    public string $payload;
+}
+```
+
+### With depth
+
+```php
+use Tempest\Validation\Rules\Json;
+
+final class Data
+{
+    #[Json(depth: 512)]
+    public string $payload;
+}
+```
+
+### With flags
+
+```php
+use Tempest\Validation\Rules\Json;
+use const JSON_THROW_ON_ERROR;
+
+final class Data
+{
+    #[Json(flags: JSON_THROW_ON_ERROR)]
+    public string $payload;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/28-length.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/28-length.md
@@ -1,0 +1,56 @@
+---
+title: Length
+description: "Validate the length of a string."
+---
+
+## Overview
+
+This rule validates the length of a string. You can specify a minimum, a maximum, or both.
+
+## Parameters
+
+- `$min` (`?int`): The minimum allowed length. Defaults to `null`.
+- `$max` (`?int`): The maximum allowed length. Defaults to `null`.
+
+## Examples
+
+### Minimum length
+
+```php
+use Tempest\Validation\Rules\Length;
+
+final class User
+{
+    #[Length(min: 3)]
+    public string $username;
+}
+```
+
+### Maximum length
+
+```php
+use Tempest\Validation\Rules\Length;
+
+final class User
+{
+    #[Length(max: 32)]
+    public string $username;
+}
+```
+
+### Between a minimum and maximum length
+
+```php
+use Tempest\Validation\Rules\Length;
+
+final class User
+{
+    #[Length(min: 3, max: 32)]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Between](07-between.md)
+- [Tempest\Validation\Rules\Count](09-count.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/29-lowercase.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/29-lowercase.md
@@ -1,0 +1,24 @@
+---
+title: Lowercase
+description: "Validate that a string is lowercase."
+---
+
+## Overview
+
+This rule validates whether a given string value is entirely lowercase.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Lowercase;
+
+final class User
+{
+    #[Lowercase()]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Uppercase](47-uppercase.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/30-macaddress.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/30-macaddress.md
@@ -1,0 +1,20 @@
+---
+title: MACAddress
+description: "Validate that a value is a valid MAC address."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid MAC address.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\MACAddress;
+
+final class Device
+{
+    #[MACAddress()]
+    public string $macAddress;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/31-multiple-of.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/31-multiple-of.md
@@ -1,0 +1,28 @@
+---
+title: MultipleOf
+description: "Validate that a value is a multiple of a specific number."
+---
+
+## Overview
+
+This rule validates whether a given integer value is a multiple of a specific number.
+
+## Parameters
+
+- `$divisor` (`int`): The number by which the value must be a multiple.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\MultipleOf;
+
+final class Number
+{
+    #[MultipleOf(5)]
+    public int $value;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\DivisibleBy](11-divisible-by.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/32-not-empty.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/32-not-empty.md
@@ -1,0 +1,20 @@
+---
+title: NotEmpty
+description: "Validate that a string is not empty."
+---
+
+## Overview
+
+This rule validates whether a given string value is not empty.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\NotEmpty;
+
+final class Post
+{
+    #[NotEmpty()]
+    public string $title;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/33-not-in.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/33-not-in.md
@@ -1,0 +1,28 @@
+---
+title: NotIn
+description: "Validate that a value is not one of a given set of values."
+---
+
+## Overview
+
+This rule validates whether a given value is not present in a given array of values.
+
+## Parameters
+
+- `$values` (`array<string|int>`): The array of values to check against.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\NotIn;
+
+final class User
+{
+    #[NotIn(['admin', 'root'])]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\In](18-in.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/34-not-null.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/34-not-null.md
@@ -1,0 +1,20 @@
+---
+title: NotNull
+description: "Validate that a value is not null."
+---
+
+## Overview
+
+This rule validates that a value is not `null`.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\NotNull;
+
+final class User
+{
+    #[NotNull()]
+    public string $name;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/35-numeric.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/35-numeric.md
@@ -1,0 +1,25 @@
+---
+title: Numeric
+description: "Validate that a value contains only numeric characters."
+---
+
+## Overview
+
+This rule validates whether a given string value contains only numeric characters (0-9).
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Numeric;
+
+final class User
+{
+    #[Numeric()]
+    public string $accessCode$;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\IsInteger](25-is-integer.md)
+- [Tempest\Validation\Rules\IsFloat](24-is-float.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/36-odd.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/36-odd.md
@@ -1,0 +1,24 @@
+---
+title: Odd
+description: "Validate if the value is an odd number"
+---
+
+## Overview
+
+This rule validates if the value is an odd numer.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Odd;
+
+final class Book
+{
+    #[Odd()]
+    public string $number;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Even](16-even.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/37-password.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/37-password.md
@@ -1,0 +1,78 @@
+---
+title: Password
+description: "Validate that a string is a valid password."
+---
+
+## Overview
+
+This rule validates whether a given string value meets a set of password requirements.
+
+## Parameters
+
+- `$min` (`int`): The minimum length of the password. Defaults to `12`.
+- `$mixedCase` (`bool`): Whether the password must contain both uppercase and lowercase letters. Defaults to `false`.
+- `$numbers` (`bool`): Whether the password must contain at least one number. Defaults to `false`.
+- `$letters` (`bool`): Whether the password must contain at least one letter. Defaults to `false`.
+- `$symbols` (`bool`): Whether the password must contain at least one symbol. Defaults to `false`.
+
+## Examples
+
+### Minimum length
+
+```php
+use Tempest\Validation\Rules\Password;
+
+final class User
+{
+    #[Password(min: 8)]
+    public string $password;
+}
+```
+
+### Require mixed case
+
+```php
+use Tempest\Validation\Rules\Password;
+
+final class User
+{
+    #[Password(mixedCase: true)]
+    public string $password;
+}
+```
+
+### Require numbers
+
+```php
+use Tempest\Validation\Rules\Password;
+
+final class User
+{
+    #[Password(numbers: true)]
+    public string $password;
+}
+```
+
+### Require letters
+
+```php
+use Tempest\Validation\Rules\Password;
+
+final class User
+{
+    #[Password(letters: true)]
+    public string $password;
+}
+```
+
+### Require symbols
+
+```php
+use Tempest\Validation\Rules\Password;
+
+final class User
+{
+    #[Password(symbols: true)]
+    public string $password;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/38-phone-number.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/38-phone-number.md
@@ -1,0 +1,38 @@
+---
+title: PhoneNumber
+description: "Validate that a value is a valid phone number."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid phone number. You can optionally provide a default region.
+
+## Parameters
+
+- `$defaultRegion` (`?string`): The default region code (e.g., `NL`, `BE`). Defaults to `null`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\PhoneNumber;
+
+final class User
+{
+    #[PhoneNumber()]
+    public string $phoneNumber;
+}
+```
+
+### With default region
+
+```php
+use Tempest\Validation\Rules\PhoneNumber;
+
+final class User
+{
+    #[PhoneNumber(defaultRegion: 'NL')]
+    public string $phoneNumber;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/39-reg-ex.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/39-reg-ex.md
@@ -1,0 +1,24 @@
+---
+title: RegEx
+description: "Validate that a value matches a regular expression."
+---
+
+## Overview
+
+This rule validates whether a given string value matches a regular expression.
+
+## Parameters
+
+- `$pattern` (`string`): The regular expression pattern to match against.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\RegEx;
+
+final class User
+{
+    #[RegEx('/^[a-z]+$/')]
+    public string $username;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/40-should-be-false.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/40-should-be-false.md
@@ -1,0 +1,25 @@
+---
+title: ShouldBeFalse
+description: "Validate that a value is false."
+---
+
+## Overview
+
+This rule validates whether a given value is `false`, `'false'`, `0`, or `'0'`.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\ShouldBeFalse;
+
+final class User
+{
+    #[ShouldBeFalse()]
+    public bool $isActive;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\ShouldBeTrue](41-should-be-true.md)
+- [Tempest\Validation\Rules\IsBoolean](22-is-boolean.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/41-should-be-true.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/41-should-be-true.md
@@ -1,0 +1,25 @@
+---
+title: ShouldBeTrue
+description: "Validate that a value is true."
+---
+
+## Overview
+
+This rule validates whether a given value is `true`, `'true'`, `1`, or `'1'`.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\ShouldBeTrue;
+
+final class User
+{
+    #[ShouldBeTrue()]
+    public bool $isActive;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\ShouldBeFalse](40-should-be-false.md)
+- [Tempest\Validation\Rules\IsBoolean](22-is-boolean.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/42-starts-with.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/42-starts-with.md
@@ -1,0 +1,29 @@
+---
+title: StartsWith
+description: "Validate that a value starts with a specific string."
+---
+
+## Overview
+
+This rule validates whether a given string value starts with a specific string.
+
+## Parameters
+
+- `$needle` (`string`): The string that the value must start with.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\StartsWith;
+
+final class User
+{
+    #[StartsWith('tempest-')]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\DoesNotStartWith](13-does-not-start-with.md)
+- [Tempest\Validation\Rules\EndsWith](15-ends-with.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/43-time.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/43-time.md
@@ -1,0 +1,43 @@
+---
+title: Time
+description: "Validate that a value is a valid time."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid time. You can specify whether the time should be in 24-hour format.
+
+## Parameters
+
+- `$twentyFourHour` (`bool`): Whether the time should be in 24-hour format. Defaults to `false`.
+
+## Examples
+
+### 12-hour format
+
+```php
+use Tempest\Validation\Rules\Time;
+
+final class Event
+{
+    #[Time()]
+    public string $startTime;
+}
+```
+
+### 24-hour format
+
+```php
+use Tempest\Validation\Rules\Time;
+
+final class Event
+{
+    #[Time(twentyFourHour: true)]
+    public string $startTime;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\DateTimeFormat](10-date-time-format.md)
+- [Tempest\Validation\Rules\Timestamp](44-timestamp.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/44-timestamp.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/44-timestamp.md
@@ -1,0 +1,25 @@
+---
+title: Timestamp
+description: "Validate that a value is a valid timestamp."
+---
+
+## Overview
+
+This rule validates whether a given integer value is a valid Unix timestamp.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Timestamp;
+
+final class Event
+{
+    #[Timestamp()]
+    public int $startTime;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\DateTimeFormat](10-date-time-format.md)
+- [Tempest\Validation\Rules\Time](43-time.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/45-timezone.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/45-timezone.md
@@ -1,0 +1,53 @@
+---
+title: Timezone
+description: "Validate that a value is a valid timezone."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid timezone identifier.
+
+## Parameters
+
+- `$timezoneGroup` (`int`): A bitmask of `DateTimeZone` constants (e.g., `DateTimeZone::ASIA`, `DateTimeZone::PER_COUNTRY`). Defaults to `DateTimeZone::ALL`.
+- `$countryCode` (`?string`): A two-letter ISO 3166-1 alpha-2 country code when `timezoneGroup` is `DateTimeZone::PER_COUNTRY`. Defaults to `null`.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\Timezone;
+
+final class User
+{
+    #[Timezone()]
+    public string $timezone;
+}
+```
+
+### With timezone group
+
+```php
+use Tempest\Validation\Rules\Timezone;
+use const DateTimeZone::EUROPE;
+
+final class User
+{
+    #[Timezone(timezoneGroup:EUROPE)]
+    public string $timezone;
+}
+```
+
+### With country code
+
+```php
+use Tempest\Validation\Rules\Timezone;
+use const DateTimeZone::PER_COUNTRY;
+
+final class User
+{
+    #[Timezone(timezoneGroup: PER_COUNTRY, countryCode: 'NL')]
+    public string $timezone;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/46-ulid.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/46-ulid.md
@@ -1,0 +1,24 @@
+---
+title: Ulid
+description: "Validate that a value is a valid ULID."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid ULID.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Ulid;
+
+final class Post
+{
+    #[Ulid()]
+    public string $id;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Uuid](49-uuid.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/47-uppercase.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/47-uppercase.md
@@ -1,0 +1,24 @@
+---
+title: Uppercase
+description: "Validate that a string is uppercase."
+---
+
+## Overview
+
+This rule validates whether a given string value is entirely uppercase.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Uppercase;
+
+final class User
+{
+    #[Uppercase()]
+    public string $username;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Lowercase](29-lowercase.md)

--- a/src/Web/Documentation/content/1.x/6-validation-rules/48-url.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/48-url.md
@@ -1,0 +1,38 @@
+---
+title: Url
+description: "Validate that a value is a valid URL."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid URL. You can optionally provide a list of allowed protocols.
+
+## Parameters
+
+- `$protocols` (`string[]`): An array of allowed protocols (e.g., `http`, `https`, `ftp`). Defaults to an empty array, which allows all common protocols.
+
+## Examples
+
+### Default
+
+```php
+use Tempest\Validation\Rules\Url;
+
+final class Link
+{
+    #[Url()]
+    public string $url;
+}
+```
+
+### With specific protocols
+
+```php
+use Tempest\Validation\Rules\Url;
+
+final class Link
+{
+    #[Url(['ftp', 'ftps'])]
+    public string $url;
+}
+```

--- a/src/Web/Documentation/content/1.x/6-validation-rules/49-uuid.md
+++ b/src/Web/Documentation/content/1.x/6-validation-rules/49-uuid.md
@@ -1,0 +1,24 @@
+---
+title: Uuid
+description: "Validate that a value is a valid UUID."
+---
+
+## Overview
+
+This rule validates whether a given string value is a valid UUID.
+
+## Example
+
+```php
+use Tempest\Validation\Rules\Uuid;
+
+final class Post
+{
+    #[Uuid()]
+    public string $id;
+}
+```
+
+## See also
+
+- [Tempest\Validation\Rules\Ulid](46-ulid.md)


### PR DESCRIPTION
Using the magic of the Google Gemini CLI code generator, I have created documentation for the validation rules in located in the `Tempest\Validation\Rules`-namespace. Each rule document has the following sections:

- **Overview** - contains one or two sentences about the rule
- **Parameters** - list of rule parameters (optional)
- **Example(s)** - One or more examples 
- **See also** - Links to similar rules (optional)

I have placed the rules in a new section called `Validation Rules`, the first article contains an overview with some generic information. Next section contains links to the the rules organized per category.

Open questions:
- Do you want other kind of examples or sections added to the rule documents?
- Do you want to keep the rules in this location? 

Please let me know if you have any questions!

Fixes: https://github.com/tempestphp/tempest-framework/issues/1034