### PR TITLE
feat(docs): add an section about loading additional config for tests

### DIFF
--- a/src/Web/Documentation/content/1.x/1-essentials/07-testing.md
+++ b/src/Web/Documentation/content/1.x/1-essentials/07-testing.md
@@ -38,13 +38,39 @@ final class HomeControllerTest extends IntegrationTestCase
 }
 ```
 
+## Additional configuration
+
+By default, only the entries inside the `require` key of the `composer.json` file are discovered.
+As such if the tests need additional configuration, these locations need to be discovered manually.
+In which case you may add these locations to the `discoveryLocations` property of the `IntegrationTestCase` class.
+
+For example `tests/Config` contains configuration that is only needed for tests, like database configuration.
+
+```php tests/IntegrationTestCase.php
+use Tempest\Core\DiscoveryLocation;
+
+final class IntegrationTestCase extends TestCase
+{
+    protected string $root = __DIR__ . '/../';
+
+    protected function setUp(): void
+    {
+        $this->discoveryLocations = [
+            new DiscoveryLocation(namespace: 'Tests\\Config', path: __DIR__ . '/Config'),
+        ];
+
+        parent::setUp();
+    }
+}
+```
+
 ## Changing the location of tests
 
 The `phpunit.xml` file contains a `{html}<testsuite>` element that configures the directory in which PHPUnit looks for test files. This may be changed to follow any rule of your convenience.
 
 For instance, you may colocate test files and their corresponding class by changing the `{html}suffix` attribute in `phpunit.xml` to the following:
 
-```diff
+```diff phpunit.xml
 <testsuites>
 	<testsuite name="Tests">
 -		<directory suffix="Test.php">./tests</directory>


### PR DESCRIPTION
closes #1443

I've added a section that talks about using additonal configuration inside the `tests` directory.
For example if a different database config is needed for the tests.

Screenshot is added below.

<details><summary>Screenshot</summary>
<p>

<img width="871" height="692" alt="image" src="https://github.com/user-attachments/assets/be0c8f55-9069-4363-8056-e23470be0e52" />

</p>
</details> 
