### PR TITLE
chore: add tempest-twig package in the community page

### DIFF
--- a/src/Web/Community/community-posts.yaml
+++ b/src/Web/Community/community-posts.yaml
@@ -1,6 +1,6 @@
 - uri: https://github.com/tamdaz/tempest-twig
   title: Tempest + Twig
-  description: A third-party package that provides Twig functions helpers for Tempest
+  description: A third-party package that provides helper functions and allows creating Twig components for Tempest.
   type: Package
 - uri: https://www.juststeveking.com/articles/the-reason-i-love-tempest-for-apis/
   title: The Reason I Love Tempest for APIs

--- a/src/Web/Community/community-posts.yaml
+++ b/src/Web/Community/community-posts.yaml
@@ -1,3 +1,7 @@
+- uri: https://github.com/tamdaz/tempest-twig
+  title: Tempest + Twig
+  description: A third-party package that provides Twig functions helpers for Tempest
+  type: Package
 - uri: https://www.juststeveking.com/articles/the-reason-i-love-tempest-for-apis/
   title: The Reason I Love Tempest for APIs
   description: Tempest makes API development feel lightweight by combining typed request objects, attribute-based validation, discovery-driven routing, and built-in mapping with minimal ceremony.


### PR DESCRIPTION
## Description

I would like to add my `tempest-twig` package to the community page. This shows the progressive evolution of Tempest's third-party packages.